### PR TITLE
Add multiplatform docker build workflow and tag images for integratio…

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -45,3 +45,17 @@ jobs:
         run: npm run docker:contracts
       - name: Push docker image
         run: npm run push:docker:contracts
+      # Steps to push multi-platform image, it relies on the previous step:
+      #  npm run docker:contracts
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: hermeznetwork/geth-zkevm-contracts:1.5-integration
+          file: docker/Dockerfile.geth
+          context: .

--- a/docker/scripts/deploy-docker.sh
+++ b/docker/scripts/deploy-docker.sh
@@ -8,3 +8,5 @@ mkdir docker/deploymentOutput
 mv deployment/testnet/deploy_output.json docker/deploymentOutput
 docker-compose -f docker/docker-compose.geth.yml down
 sudo docker build -t hermeznetwork/geth-zkevm-contracts -f docker/Dockerfile.geth .
+# Let it readable for the multiplatform build coming later!
+sudo chmod -R go+rxw docker/gethData


### PR DESCRIPTION
Small changes to GitHub workflows to build multi platform docker images that can be directly run also in ARM MacBook computers. Also set new tags for integration and internal-testnet purposes: 1.5-integration and 1.5-itestnet