### PR TITLE
Fix IBridgeMessageReceiver.sol

### DIFF
--- a/contracts/interfaces/IBridgeMessageReceiver.sol
+++ b/contracts/interfaces/IBridgeMessageReceiver.sol
@@ -10,5 +10,5 @@ interface IBridgeMessageReceiver {
         address originAddress,
         uint32 originNetwork,
         bytes memory data
-    ) external view returns (bool);
+    ) external payable;
 }


### PR DESCRIPTION
- Changed function type from view to payable.
- Get rid of the return value bool.