### PR TITLE
fix: `Ownable` -> `Ownable2Step`

### DIFF
--- a/contracts/PolygonZkEVM.sol
+++ b/contracts/PolygonZkEVM.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "./interfaces/IVerifierRollup.sol";
 import "./interfaces/IPolygonZkEVMGlobalExitRoot.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "./interfaces/IPolygonZkEVMBridge.sol";
 import "./lib/EmergencyManager.sol";
 import "./interfaces/IPolygonZkEVMErrors.sol";
@@ -18,7 +18,7 @@ import "./interfaces/IPolygonZkEVMErrors.sol";
  * To enter and exit of the L2 network will be used a PolygonZkEVMBridge smart contract that will be deployed in both networks.
  */
 contract PolygonZkEVM is
-    OwnableUpgradeable,
+    Ownable2StepUpgradeable,
     EmergencyManager,
     IPolygonZkEVMErrors
 {
@@ -428,7 +428,7 @@ contract PolygonZkEVM is
         isForcedBatchDisallowed = true;
 
         // Initialize OZ contracts
-        __Ownable_init_unchained();
+        __Ownable2Step_init();
 
         // emit version event
         emit UpdateZkEVMVersion(0, forkID, _version);

--- a/contracts/deployment/PolygonZkEVMDeployer.sol
+++ b/contracts/deployment/PolygonZkEVMDeployer.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.17;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * Contract responsible for deploying deterministic address contracts related with the PolygonZkEVM
  */
-contract PolygonZkEVMDeployer is Ownable {
+contract PolygonZkEVMDeployer is Ownable2Step {
     /**
      * @param _owner Owner
      */
-    constructor(address _owner) Ownable() {
+    constructor(address _owner) Ownable2Step() {
         _transferOwnership(_owner);
     }
 

--- a/contracts/mocks/PolygonZkEVMBridgeMock.sol
+++ b/contracts/mocks/PolygonZkEVMBridgeMock.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.17;
 import "../PolygonZkEVMBridge.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 /**
  * PolygonZkEVMBridge that will be deployed on both networks Ethereum and Polygon zkEVM
  * Contract responsible to manage the token interactions with other networks
  */
-contract PolygonZkEVMBridgeMock is PolygonZkEVMBridge, OwnableUpgradeable {
+contract PolygonZkEVMBridgeMock is PolygonZkEVMBridge, Ownable2StepUpgradeable {
     uint256 public maxEtherBridge;
 
     /**
@@ -26,7 +26,7 @@ contract PolygonZkEVMBridgeMock is PolygonZkEVMBridge, OwnableUpgradeable {
         maxEtherBridge = 0.25 ether;
 
         // Initialize OZ contracts
-        __Ownable_init_unchained();
+        __Ownable2Step_init();
     }
 
     function setNetworkID(uint32 _networkID) public onlyOwner {


### PR DESCRIPTION
## Motivation

Use more robust ownership transfer system, in alignment with the other contract suites.

## Solution

Change all ownables to `Ownable2Step`.