### PR TITLE
Fix `undefined` error in 3_deployContracts.js

### DIFF
--- a/deployment/3_deployContracts.js
+++ b/deployment/3_deployContracts.js
@@ -309,9 +309,8 @@ async function main() {
         ongoingDeployment.polygonZkEVMGlobalExitRoot = polygonZkEVMGlobalExitRoot.address;
         fs.writeFileSync(pathOngoingDeploymentJson, JSON.stringify(ongoingDeployment, null, 1));
     } else {
-        // sanity check
-        expect(precalculateGLobalExitRootAddress).to.be.equal(polygonZkEVMGlobalExitRoot.address);
-        // Expect the precalculate address matches de onogin deployment
+        // sanity check. Expect the precalculate address matches de onogin deployment
+        expect(precalculateGLobalExitRootAddress).to.be.equal(ongoingDeployment.polygonZkEVMGlobalExitRoot);
         polygonZkEVMGlobalExitRoot = PolygonZkEVMGlobalExitRootFactory.attach(ongoingDeployment.polygonZkEVMGlobalExitRoot);
 
         console.log('#######################\n');


### PR DESCRIPTION
## Problem

I hit the following error running `npx hardhat run deployment/3_deployContracts.js --network goerli`:

```
TypeError: Cannot read properties of undefined (reading 'address')
    at main (/home/ubuntu/zkevm-contracts/deployment/3_deployContracts.js:313:90)
```

## Root Cause Analysis
when L313 is hit, `polygonZkEVMGlobalExitRoot` is undefined. reading the comments, this should read from the `deployment/deploy_ongoing.json` file so here we should use `ongoingDeployment.polygonZkEVMGlobalExitRoot`
