### PR TITLE
chore: update license in `package.json` to reflect repo license

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/0xPolygonHermez/contracts-zkEVM/issues"
   },
   "homepage": "https://github.com/0xPolygonHermez/contracts-zkEVM#readme",
-  "license": "pending",
+  "license": "AGPL-3.0",
   "dependencies": {
     "chai": "^4.3.7",
     "ethers": "^5.7.2"


### PR DESCRIPTION
Update the license field in `package.json` from `pending` to `AGPL-3.0` as per repo [license](https://github.com/0xPolygonHermez/zkevm-contracts/blob/main/LICENSE)