### PR TITLE
Use forkID 5 in deploy_parameters.json.example

### DIFF
--- a/deployment/deploy_parameters.json.example
+++ b/deployment/deploy_parameters.json.example
@@ -8,7 +8,7 @@
     "trustedAggregator":"0x617b3a3528F9cDd6630fd3301B9c8911F7Bf063D",
     "trustedAggregatorTimeout": 604799,
     "pendingStateTimeout": 604799,
-    "forkID": 1,
+    "forkID": 5,
     "admin":"0x617b3a3528F9cDd6630fd3301B9c8911F7Bf063D",
     "zkEVMOwner": "0x617b3a3528F9cDd6630fd3301B9c8911F7Bf063D",
     "timelockAddress": "0x617b3a3528F9cDd6630fd3301B9c8911F7Bf063D",


### PR DESCRIPTION
PUSH0 is used in the contracts but the opcode was only added in the latest prover