### PR TITLE
avoid confusion in README.md

### DIFF
--- a/deployment/testV1ToV2/README.md
+++ b/deployment/testV1ToV2/README.md
@@ -30,7 +30,7 @@ deploy:testnet:v1ToV2:localhost
 -   `admin`:address, Admin address, can adjust RollupManager parameters or stop the emergency state
 -   `trustedAggregator`:address, Trusted aggregator address
 -   `trustedAggregatorTimeout`: uint64, If a sequence is not verified in this timeout everyone can verify it
--   `pendingStateTimeout`: uint64, Once a pending state exceeds this timeout it can be consolidated
+-   `pendingStateTimeout`: uint64, Once a pending state exceeds this timeout it can be consolidated by everyone
 -   `emergencyCouncilAddress`:address, Emergency council addres
 -   `polTokenAddress`: address, Matic token address, only if deploy on testnet can be left blank and will fullfilled by the scripts.
 -   `zkEVMDeployerAddress`: address, Address of the `PolygonZkEVMDeployer`. Can be left blank, will be fullfilled automatically with the `deploy:deployer:ZkEVM:goerli` script.

--- a/deployment/v2/README.md
+++ b/deployment/v2/README.md
@@ -63,7 +63,7 @@ A new folder will be created witth the following name `deployments/${network}_$(
 -   `admin`:address, Admin address, can adjust RollupManager parameters or stop the emergency state
 -   `trustedAggregator`:address, Trusted aggregator address
 -   `trustedAggregatorTimeout`: uint64, If a sequence is not verified in this timeout everyone can verify it
--   `pendingStateTimeout`: uint64, Once a pending state exceeds this timeout it can be consolidated
+-   `pendingStateTimeout`: uint64, Once a pending state exceeds this timeout it can be consolidated by everyone
 -   `emergencyCouncilAddress`:address, Emergency council addres
 -   `polTokenAddress`: address, Matic token address, only if deploy on testnet can be left blank and will fullfilled by the scripts.
 -   `zkEVMDeployerAddress`: address, Address of the `PolygonZkEVMDeployer`. Can be left blank, will be fullfilled automatically with the `deploy:deployer:ZkEVM:goerli` script.


### PR DESCRIPTION
there is 

> `trustedAggregatorTimeout`: uint64, If a sequence is not verified in this timeout everyone can verify it

so it's confusing if we don't mention that `pendingStateTimeout` means **everyone** can consolidate it after this timeout because for trusted aggregator, it doesn't need to honor this timeout:

```
    function consolidatePendingState(
        uint32 rollupID,
        uint64 pendingStateNum
    ) external {
        RollupData storage rollup = rollupIDToRollupData[rollupID];
        // Check if pending state can be consolidated
        // If trusted aggregator is the sender, do not check the timeout or the emergency state
        if (!hasRole(_TRUSTED_AGGREGATOR_ROLE, msg.sender)) {
            if (isEmergencyState) {
                revert OnlyNotEmergencyState();
            }

            if (!_isPendingStateConsolidable(rollup, pendingStateNum)) {
                revert PendingStateNotConsolidable();
            }
        }
        _consolidatePendingState(rollup, pendingStateNum);
    }
```