### PR TITLE
feat(v2): add setCustomTokenMapping

### DIFF
--- a/contracts/v2/PolygonRollupManager.sol
+++ b/contracts/v2/PolygonRollupManager.sol
@@ -561,6 +561,7 @@ contract PolygonRollupManager is
         uint64 chainID,
         address admin,
         address sequencer,
+        address bridgeManager,
         address gasTokenAddress,
         string memory sequencerURL,
         string memory networkName
@@ -621,6 +622,7 @@ contract PolygonRollupManager is
             admin,
             sequencer,
             rollupID,
+            bridgeManager,
             gasTokenAddress,
             sequencerURL,
             networkName

--- a/contracts/v2/PolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/PolygonZkEVMBridgeV2.sol
@@ -727,6 +727,25 @@ contract PolygonZkEVMBridgeV2 is
     }
 
     /**
+     * @notice Set the address of a wrapper using the token information if already exist
+     * @dev This function is used to allow any existing token to be mapped with
+     *      origin token. Wrapper contract should handle mint/burn of the existing token.
+     * @param originNetwork Origin network
+     * @param originTokenAddress Origin token address, 0 address is reserved for ether
+     * @param wrappedTokenAddress Arbitary contract that implements TokenWrapped interface
+     */
+    function setTokenWrappedAddress(
+        uint32 originNetwork,
+        address originTokenAddress,
+        address wrappedTokenAddress
+    ) external onlyRollupManager {
+        bytes32 tokenInfoHash = keccak256(
+            abi.encodePacked(originNetwork, originTokenAddress)
+        );
+        tokenInfoToWrappedToken[tokenInfoHash] = wrappedTokenAddress;
+    }
+
+    /**
      * @notice Function to activate the emergency state
      " Only can be called by the Polygon ZK-EVM in extreme situations
      */

--- a/contracts/v2/PolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/PolygonZkEVMBridgeV2.sol
@@ -76,7 +76,7 @@ contract PolygonZkEVMBridgeV2 is
     mapping(address => TokenInformation) public wrappedTokenToTokenInfo;
 
     // Existing token address --> Custom wrapper contract
-    mapping(address => address) public existingTokenToWrapper;
+    mapping(address existingToken => address customWrapper) public existingTokenToWrapper;
 
     // Rollup manager address, previously PolygonZkEVM
     /// @custom:oz-renamed-from polygonZkEVMaddress

--- a/contracts/v2/PolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/PolygonZkEVMBridgeV2.sol
@@ -755,9 +755,10 @@ contract PolygonZkEVMBridgeV2 is
         tokenInfoToWrappedToken[tokenInfoHash] = wrappedTokenAddress;
 
         // Handle bridgeAsset from origin chain
-        wrappedTokenToTokenInfo[
-            existingTokenAddress
-        ] = TokenInformation(originNetwork, originTokenAddress);
+        wrappedTokenToTokenInfo[existingTokenAddress] = TokenInformation(
+            originNetwork,
+            originTokenAddress
+        );
         existingTokenToWrapper[existingTokenAddress] = wrappedTokenAddress;
     }
 

--- a/contracts/v2/PolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/PolygonZkEVMBridgeV2.sol
@@ -76,7 +76,8 @@ contract PolygonZkEVMBridgeV2 is
     mapping(address => TokenInformation) public wrappedTokenToTokenInfo;
 
     // Existing token address --> Custom wrapper contract
-    mapping(address existingToken => address customWrapper) public existingTokenToWrapper;
+    mapping(address existingToken => address customWrapper)
+        public existingTokenToWrapper;
 
     // Rollup manager address, previously PolygonZkEVM
     /// @custom:oz-renamed-from polygonZkEVMaddress
@@ -742,7 +743,7 @@ contract PolygonZkEVMBridgeV2 is
      * @param originTokenAddress Origin token address, 0 address is reserved for ether
      * @param wrappedTokenAddress Arbitary contract that implements TokenWrapped interface
      */
-    function setTokenWrappedAddress(
+    function setCustomTokenMapping(
         uint32 originNetwork,
         address originTokenAddress,
         address wrappedTokenAddress,

--- a/contracts/v2/interfaces/IPolygonRollupBase.sol
+++ b/contracts/v2/interfaces/IPolygonRollupBase.sol
@@ -7,6 +7,7 @@ interface IPolygonRollupBase {
         address _admin,
         address sequencer,
         uint32 networkID,
+        address _bridgeManager,
         address gasTokenAddress,
         string memory sequencerURL,
         string memory _networkName

--- a/contracts/v2/interfaces/IPolygonZkEVMBridgeV2.sol
+++ b/contracts/v2/interfaces/IPolygonZkEVMBridgeV2.sol
@@ -70,6 +70,12 @@ interface IPolygonZkEVMBridgeV2 {
     error OnlyRollupManager();
 
     /**
+     * @dev Thrown when sender is not the bridge manager
+     * @notice Bridge manager can set custom mapping for any token
+     */
+    error OnlyBridgeManager();
+
+    /**
      * @dev Thrown when the permit data contains an invalid signature
      */
     error NativeTokenIsEther();
@@ -157,6 +163,7 @@ interface IPolygonZkEVMBridgeV2 {
         uint32 _gasTokenNetwork,
         IBasePolygonZkEVMGlobalExitRoot _globalExitRootManager,
         address _polygonRollupManager,
+        address _bridgeManager,
         bytes memory _gasTokenMetadata
     ) external;
 

--- a/contracts/v2/mocks/CustomWrapperMock.sol
+++ b/contracts/v2/mocks/CustomWrapperMock.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0
+// Custom Wrapper Example
+pragma solidity 0.8.20;
+
+import "../../mocks/ERC20PermitMock.sol";
+
+contract ERC20ExistingMock is ERC20PermitMock("ERC20", "ER20", address(6), 0) {
+    function burn(address account, uint256 value) public {
+        _burn(account, value);
+    }
+}
+
+/**
+ * @title CustomTokenWrapperMock
+ * @notice Example of custom wrapper.
+ *         mint and burn function can be complex but this mock
+ *         only basic functionality
+ */
+contract CustomTokenWrapperMock {
+    ERC20ExistingMock token;
+
+    constructor(address _token) {
+        token = ERC20ExistingMock(_token);
+    }
+
+    function mint(address to, uint256 value) external {
+        token.mint(to, value);
+    }
+
+    function burn(address account, uint256 value) external {
+        token.burn(account, value);
+    }
+}

--- a/test/contractsv2/BridgeV2.test.ts
+++ b/test/contractsv2/BridgeV2.test.ts
@@ -80,6 +80,7 @@ describe("PolygonZkEVMBridge Contract", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManager.address,
+            deployer.address, // Deployer as bridge manager
             "0x"
         );
 
@@ -106,6 +107,7 @@ describe("PolygonZkEVMBridge Contract", () => {
                 ethers.ZeroAddress, // zero for ether
                 polygonZkEVMGlobalExitRoot.target,
                 rollupManager.address,
+                deployer.address, // Deployer as bridge manager
                 "0x"
             )
         ).to.be.revertedWith("Initializable: contract is already initialized");

--- a/test/contractsv2/BridgeV2CustomTokens.test.ts
+++ b/test/contractsv2/BridgeV2CustomTokens.test.ts
@@ -126,6 +126,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
             0,
             polygonZkEVMGlobalExitRoot.target,
             rollupManager.address,
+            deployer.address, // deployer as bridge manager
             "0x"
         );
     });
@@ -139,7 +140,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const customWrapper = await wrapperFactory.deploy(existingToken.target);
 
         await polygonZkEVMBridge
-            .connect(rollupManager)
+            .connect(deployer)
             .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
         const tokenInfo = ethers.solidityPackedKeccak256(["uint32", "address"], [originNetworkId, tokenAddress]);
@@ -311,9 +312,9 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const wrapperFactory = await ethers.getContractFactory("CustomTokenWrapperMock");
         const customWrapper = await wrapperFactory.deploy(existingToken.target);
 
-        // 3. rollupManager set the custom wrapper
+        // 3. Bridge manager set the custom wrapper
         await polygonZkEVMBridge
-            .connect(rollupManager)
+            .connect(deployer)
             .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
         // 4. Alice claim
@@ -500,9 +501,9 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const wrapperFactory = await ethers.getContractFactory("CustomTokenWrapperMock");
         const customWrapper = await wrapperFactory.deploy(existingToken.target);
 
-        // 3. rollupManager set the custom wrapper
+        // 3. Bridge manager set the custom wrapper
         await polygonZkEVMBridge
-            .connect(rollupManager)
+            .connect(deployer)
             .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
         // 4. Alice claim
@@ -614,9 +615,9 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const wrapperFactory = await ethers.getContractFactory("CustomTokenWrapperMock");
         const customWrapper = await wrapperFactory.deploy(existingToken.target);
 
-        // 5. rollupManager set the custom wrapper
+        // 5. Bridge manager set the custom wrapper
         await polygonZkEVMBridge
-            .connect(rollupManager)
+            .connect(deployer)
             .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
         const depositCount = await polygonZkEVMBridge.depositCount();

--- a/test/contractsv2/BridgeV2CustomTokens.test.ts
+++ b/test/contractsv2/BridgeV2CustomTokens.test.ts
@@ -553,4 +553,93 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const balance = await existingToken.balanceOf(alice.address);
         expect(balance).to.be.equal(0);
     });
+
+    it("should bridge default wrapped tokens after set custom mapping", async () => {
+        // 1. we need to setup the Sparse Merkle Tree proofs
+        const originNetworkId = networkId + 1; // NOTE: non-local tokens
+        let tokenAddress = token.target;
+        let destinationNetworkId = networkId;
+        const destinationAddress = alice.address;
+        const amount = ethers.parseEther("1.0");
+        const [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot] = await _setProofs(
+            originNetworkId,
+            tokenAddress as string,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            tokenMetadata,
+            polygonZkEVMGlobalExitRoot.connect(rollupManager)
+        );
+
+        // 2. We need to get the address of token wrapper
+        const tokenWrappedFactory = await ethers.getContractFactory("TokenWrapped");
+        const salt = ethers.solidityPackedKeccak256(["uint32", "address"], [originNetworkId, tokenAddress]);
+        const minimalBytecodeProxy = await polygonZkEVMBridge.BASE_INIT_BYTECODE_WRAPPED_TOKEN();
+        const hashInitCode = ethers.solidityPackedKeccak256(["bytes", "bytes"], [minimalBytecodeProxy, tokenMetadata]);
+        const precalculateWrappedErc20 = await ethers.getCreate2Address(
+            polygonZkEVMBridge.target as string,
+            salt,
+            hashInitCode
+        );
+        const defaultWrappedToken = tokenWrappedFactory.attach(precalculateWrappedErc20) as TokenWrapped;
+
+        // 3. Alice claim
+        await expect(
+            polygonZkEVMBridge.claimAsset(
+                proofLocal,
+                proofRollup,
+                globalIndex,
+                lastMainnetExitRoot,
+                lastRollupExitRoot,
+                originNetworkId,
+                tokenAddress,
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                tokenMetadata
+            )
+        )
+            .to.emit(polygonZkEVMBridge, "ClaimEvent")
+            .withArgs(globalIndex, originNetworkId, tokenAddress, destinationAddress, amount)
+            .to.emit(polygonZkEVMBridge, "NewWrappedToken")
+            .withArgs(originNetworkId, tokenAddress, precalculateWrappedErc20, tokenMetadata)
+            .to.emit(defaultWrappedToken, "Transfer")
+            .withArgs(ethers.ZeroAddress, destinationAddress, amount);
+
+        // At this point; default wrapped token is already minted
+
+        // 4. we need to deploy existing token and the wrapper
+        const tokenFactory = await ethers.getContractFactory("ERC20ExistingMock");
+        const existingToken = await tokenFactory.deploy();
+        const wrapperFactory = await ethers.getContractFactory("CustomTokenWrapperMock");
+        const customWrapper = await wrapperFactory.deploy(existingToken.target);
+
+        // 5. rollupManager set the custom wrapper
+        await polygonZkEVMBridge
+            .connect(rollupManager)
+            .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
+
+        const depositCount = await polygonZkEVMBridge.depositCount();
+        tokenAddress = defaultWrappedToken.target; // Update with the address of wrapped token
+        destinationNetworkId = networkId + 1;
+        const metadata = tokenMetadata;
+
+        // 6. Alice bridge the default wrapper
+        await expect(
+            polygonZkEVMBridge
+                .connect(alice)
+                .bridgeAsset(destinationNetworkId, destinationAddress, amount, tokenAddress, true, "0x")
+        )
+            .to.emit(polygonZkEVMBridge, "BridgeEvent")
+            .withArgs(
+                LEAF_TYPE_ASSET,
+                originNetworkId,
+                token.target, // NOTE: Target token should be the original address
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                metadata,
+                depositCount
+            );
+    });
 });

--- a/test/contractsv2/BridgeV2CustomTokens.test.ts
+++ b/test/contractsv2/BridgeV2CustomTokens.test.ts
@@ -128,10 +128,6 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
             rollupManager.address,
             "0x"
         );
-
-        // Set custom wrapped token address
-
-        // await polygonZkEVMBridge.setTokenWrappedAddress()
     });
 
     it("should set correct custom wrapper storages", async () => {
@@ -144,7 +140,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
 
         await polygonZkEVMBridge
             .connect(rollupManager)
-            .setTokenWrappedAddress(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
+            .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
         const tokenInfo = ethers.solidityPackedKeccak256(["uint32", "address"], [originNetworkId, tokenAddress]);
         const wrapepdTokenAddress = await polygonZkEVMBridge.tokenInfoToWrappedToken(tokenInfo);
@@ -318,7 +314,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         // 3. rollupManager set the custom wrapper
         await polygonZkEVMBridge
             .connect(rollupManager)
-            .setTokenWrappedAddress(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
+            .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
         // 4. Alice claim
         await expect(
@@ -507,7 +503,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         // 3. rollupManager set the custom wrapper
         await polygonZkEVMBridge
             .connect(rollupManager)
-            .setTokenWrappedAddress(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
+            .setCustomTokenMapping(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
         // 4. Alice claim
         await polygonZkEVMBridge.claimAsset(

--- a/test/contractsv2/BridgeV2CustomTokens.test.ts
+++ b/test/contractsv2/BridgeV2CustomTokens.test.ts
@@ -1,0 +1,153 @@
+import {expect} from "chai";
+import {ethers, upgrades} from "hardhat";
+import {type HardhatEthersSigner} from "@nomicfoundation/hardhat-ethers/signers";
+
+import {
+    processorUtils,
+    contractUtils,
+    MTBridge as MerkleTreeBridge,
+    mtBridgeUtils,
+} from "@0xpolygonhermez/zkevm-commonjs";
+import {type PolygonZkEVMGlobalExitRootV2, type PolygonZkEVMBridgeV2, ERC20PermitMock} from "../../typechain-types";
+
+const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
+
+function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: Boolean) {
+    if (isMainnet === true) {
+        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
+    } else {
+        return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
+    }
+}
+
+describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
+    // Signers
+    let bridgor: HardhatEthersSigner;
+    let deployer: HardhatEthersSigner;
+    let rollupManager: HardhatEthersSigner;
+    let acc1: HardhatEthersSigner;
+
+    // Contracts
+    let polygonZkEVMBridge: PolygonZkEVMBridgeV2;
+    let polygonZkEVMGlobalExitRoot: PolygonZkEVMGlobalExitRootV2;
+    let token: ERC20PermitMock;
+
+    const originNetworkId = 0;
+    const destinationNetworkId = 1;
+
+    const networkIDMainnet = 0;
+    const LEAF_TYPE_ASSET = 0;
+
+    beforeEach("Deploy contracts", async () => {
+        // Load signers
+        [bridgor, deployer, rollupManager, acc1] = await ethers.getSigners();
+
+        // Deploy PolygonZkEVMBridge
+        const polygonZkEVMBridgeFactory = await ethers.getContractFactory("PolygonZkEVMBridgeV2");
+        polygonZkEVMBridge = (await upgrades.deployProxy(polygonZkEVMBridgeFactory, [], {
+            initializer: false,
+            unsafeAllow: ["constructor"],
+        })) as unknown as PolygonZkEVMBridgeV2;
+
+        // Deploy PolygonZkEVMGlobalExitRoot
+        const PolygonZkEVMGlobalExitRootFactory = await ethers.getContractFactory("PolygonZkEVMGlobalExitRootV2");
+        polygonZkEVMGlobalExitRoot = await PolygonZkEVMGlobalExitRootFactory.deploy(
+            rollupManager.address,
+            polygonZkEVMBridge.target
+        );
+
+        // Initialize PolygonZkEVMBridge on Destination Network
+        await polygonZkEVMBridge.initialize(
+            destinationNetworkId,
+            ethers.ZeroAddress, // zero for ether
+            ethers.ZeroAddress, // zero for ether
+            polygonZkEVMGlobalExitRoot.target,
+            rollupManager.address,
+            "0x"
+        );
+
+        // Set custom wrapped token address
+
+        // await polygonZkEVMBridge.setTokenWrappedAddress()
+
+        // // Deploy Tokens
+        const tokenFactory = await ethers.getContractFactory("ERC20PermitMock");
+        token = await tokenFactory.deploy("Test Token", "TEST", deployer.address, ethers.parseEther("20000000"));
+    });
+
+    it("should claim tokens with default wrapper", async () => {
+        // Bridgor bridge USDC from originNetwork
+
+        const {verifyMerkleProof, getLeafValue} = mtBridgeUtils;
+
+        // First, we need to setup the Sparse Merkle Tree proofs
+
+        // Local merkle tree
+        const height = 32;
+        const merkleTreeLocal = new MerkleTreeBridge(height);
+        const destinationAddress = deployer.address;
+        const tokenAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+        const amount = ethers.parseEther("10000");
+        const metadata = ethers.AbiCoder.defaultAbiCoder().encode(
+            ["string", "string", "uint8"],
+            ["USD Coin", "USDC", 6]
+        );
+        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [metadata]);
+
+        const leafValue = getLeafValue(
+            LEAF_TYPE_ASSET,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            metadataHash
+        );
+        merkleTreeLocal.add(leafValue);
+        const indexLocal = 0;
+        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
+        const rootLocalRollup = merkleTreeLocal.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
+
+        // Rollup merkle tree
+        const merkleTreeRollup = new MerkleTreeBridge(height);
+        for (let i = 0; i < 10; i++) {
+            merkleTreeRollup.add(rootLocalRollup);
+        }
+        const indexRollup = 5;
+        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
+        const rootRollup = merkleTreeRollup.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
+
+        // Second, we need to update the exit root
+        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
+        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
+            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
+            .withArgs(lastMainnetExitRoot, rootRollup);
+
+        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
+        expect(lastRollupExitRoot).to.be.equal(rootRollup);
+
+        // Third, calculate the global index
+        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
+
+        const result = await polygonZkEVMBridge.claimAsset(
+            proofLocal,
+            proofRollup,
+            globalIndex,
+            lastMainnetExitRoot,
+            lastRollupExitRoot,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            metadata
+        );
+        console.log(result);
+    });
+});

--- a/test/contractsv2/BridgeV2CustomTokens.test.ts
+++ b/test/contractsv2/BridgeV2CustomTokens.test.ts
@@ -23,6 +23,8 @@ function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: Boolea
 }
 
 describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
+    upgrades.silenceWarnings();
+
     // Signers
     let deployer: HardhatEthersSigner;
     let rollupManager: HardhatEthersSigner;
@@ -31,7 +33,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
     // Contracts
     let polygonZkEVMBridge: PolygonZkEVMBridgeV2;
     let polygonZkEVMGlobalExitRoot: PolygonZkEVMGlobalExitRootV2;
-    // let gasToken: ERC20PermitMock;
+    let token: ERC20PermitMock;
 
     const networkId = 0;
     const LEAF_TYPE_ASSET = 0;
@@ -54,9 +56,9 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
             polygonZkEVMBridge.target
         );
 
-        // deploy token
-        // const tokenFactory = await ethers.getContractFactory("ERC20PermitMock");
-        // gasToken = await tokenFactory.deploy("Polygon", "POL", deployer.address, ethers.parseEther("1000000"));
+        // Deploy token
+        const tokenFactory = await ethers.getContractFactory("ERC20PermitMock");
+        token = await tokenFactory.deploy("Polygon", "POL", deployer.address, ethers.parseEther("1000000"));
 
         // Initialize PolygonZkEVMBridge on Destination Network
         await polygonZkEVMBridge.initialize(
@@ -159,6 +161,95 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
             metadata
         );
         const afterClaim = await ethers.provider.getBalance(alice.address);
+        const aliceBalance = afterClaim - beforeClaim;
+        expect(aliceBalance).eq(amount);
+    });
+
+    it("should claim local tokens", async () => {
+        // 1. we need to setup the Sparse Merkle Tree proofs
+
+        // Local merkle tree
+        const height = 32;
+        const merkleTreeLocal = new MerkleTreeBridge(height);
+
+        const originNetworkId = networkId;
+        const tokenAddress = token.target;
+        const destinationNetworkId = networkId;
+        const destinationAddress = alice.address;
+        const amount = ethers.parseEther("1.0");
+        const metadata = ethers.AbiCoder.defaultAbiCoder().encode(
+            ["string", "string", "uint8"],
+            ["Polygon", "POL", 18]
+        );
+        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [metadata]);
+
+        const leafValue = getLeafValue(
+            LEAF_TYPE_ASSET,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            metadataHash
+        );
+        merkleTreeLocal.add(leafValue);
+        const indexLocal = 0;
+        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
+        const rootLocalRollup = merkleTreeLocal.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
+
+        // Rollup merkle tree
+        const merkleTreeRollup = new MerkleTreeBridge(height);
+        for (let i = 0; i < 10; i++) {
+            merkleTreeRollup.add(rootLocalRollup);
+        }
+        const indexRollup = 5;
+        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
+        const rootRollup = merkleTreeRollup.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
+
+        // 2. we need to update the exit root
+        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
+        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
+            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
+            .withArgs(lastMainnetExitRoot, rootRollup);
+
+        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
+        expect(lastRollupExitRoot).to.be.equal(rootRollup);
+
+        // 3. we need to calculate the global index
+        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
+
+        // 4. Topup the bridge
+        await token.mint(polygonZkEVMBridge.target, amount);
+
+        // const balance = await ethers.provider.getBalance(polygonZkEVMBridge.target);
+
+        // transfer tokens, then claim
+        // await expect(gasToken.transfer(polygonZkEVMBridge.target, amount))
+        //     .to.emit(gasToken, "Transfer")
+        //     .withArgs(deployer.address, polygonZkEVMBridge.target, amount);
+
+        // 5. Alice claim
+        const beforeClaim = await token.balanceOf(alice.address);
+        await polygonZkEVMBridge.claimAsset(
+            proofLocal,
+            proofRollup,
+            globalIndex,
+            lastMainnetExitRoot,
+            lastRollupExitRoot,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            metadata
+        );
+        const afterClaim = await token.balanceOf(alice.address);
         const aliceBalance = afterClaim - beforeClaim;
         expect(aliceBalance).eq(amount);
     });

--- a/test/contractsv2/BridgeV2CustomTokens.test.ts
+++ b/test/contractsv2/BridgeV2CustomTokens.test.ts
@@ -16,6 +16,7 @@ import {
     type TokenWrapped,
 } from "../../typechain-types";
 
+const LEAF_TYPE_ASSET = 0;
 const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
 const {verifyMerkleProof, getLeafValue} = mtBridgeUtils;
 
@@ -26,6 +27,60 @@ function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: Boolea
         return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
     }
 }
+
+const _setProofs = async (
+    originNetworkId: number,
+    tokenAddress: string,
+    destinationNetworkId: number,
+    destinationAddress: string,
+    amount: bigint,
+    tokenMetadata: string,
+    contract: PolygonZkEVMGlobalExitRootV2
+) => {
+    const height = 32;
+    const merkleTreeLocal = new MerkleTreeBridge(height);
+    const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
+
+    const leafValue = getLeafValue(
+        LEAF_TYPE_ASSET,
+        originNetworkId,
+        tokenAddress,
+        destinationNetworkId,
+        destinationAddress,
+        amount,
+        metadataHash
+    );
+    merkleTreeLocal.add(leafValue);
+    const indexLocal = 0;
+    const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
+    const rootLocalRollup = merkleTreeLocal.getRoot();
+
+    // Double check the SMT Proof
+    expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
+
+    // Rollup merkle tree
+    const merkleTreeRollup = new MerkleTreeBridge(height);
+    for (let i = 0; i < 10; i++) {
+        merkleTreeRollup.add(rootLocalRollup);
+    }
+    const indexRollup = 5;
+    const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
+    const rootRollup = merkleTreeRollup.getRoot();
+
+    // Double check the SMT Proof
+    expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
+    const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
+
+    const lastMainnetExitRoot = await contract.lastMainnetExitRoot();
+    await expect(contract.updateExitRoot(rootRollup))
+        .to.emit(contract, "UpdateL1InfoTree")
+        .withArgs(lastMainnetExitRoot, rootRollup);
+
+    const lastRollupExitRoot = await contract.lastRollupExitRoot();
+    expect(lastRollupExitRoot).to.be.equal(rootRollup);
+
+    return [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot];
+};
 
 describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
     upgrades.silenceWarnings();
@@ -46,7 +101,6 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
     );
 
     const networkId = 0;
-    const LEAF_TYPE_ASSET = 0;
 
     beforeEach("Deploy contracts", async () => {
         // Load signers
@@ -87,64 +141,26 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
 
     it("should claim gas tokens", async () => {
         // 1. we need to setup the Sparse Merkle Tree proofs
-
-        // Local merkle tree
-        const height = 32;
-        const merkleTreeLocal = new MerkleTreeBridge(height);
-
         const originNetworkId = networkId;
         const tokenAddress = ethers.ZeroAddress; // NOTE: gas token
         const destinationNetworkId = networkId;
         const destinationAddress = alice.address;
         const amount = ethers.parseEther("1.0");
-        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
-
-        const leafValue = getLeafValue(
-            LEAF_TYPE_ASSET,
+        const [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot] = await _setProofs(
             originNetworkId,
             tokenAddress,
             destinationNetworkId,
             destinationAddress,
             amount,
-            metadataHash
+            tokenMetadata,
+            polygonZkEVMGlobalExitRoot.connect(rollupManager)
         );
-        merkleTreeLocal.add(leafValue);
-        const indexLocal = 0;
-        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
-        const rootLocalRollup = merkleTreeLocal.getRoot();
 
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
-
-        // Rollup merkle tree
-        const merkleTreeRollup = new MerkleTreeBridge(height);
-        for (let i = 0; i < 10; i++) {
-            merkleTreeRollup.add(rootLocalRollup);
-        }
-        const indexRollup = 5;
-        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
-        const rootRollup = merkleTreeRollup.getRoot();
-
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
-
-        // 2. we need to update the exit root
-        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
-        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
-            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
-            .withArgs(lastMainnetExitRoot, rootRollup);
-
-        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
-        expect(lastRollupExitRoot).to.be.equal(rootRollup);
-
-        // 3. we need to calculate the global index
-        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
-
-        // 4. topup the bridge
+        // 2. topup the bridge
         const bridgeBalance = ethers.parseEther("1.0");
         await setBalance(polygonZkEVMBridge.target.toString(), bridgeBalance);
 
-        // 5. Alice claim
+        // 3. Alice claim
         const beforeClaim = await ethers.provider.getBalance(alice.address);
         await polygonZkEVMBridge.claimAsset(
             proofLocal,
@@ -166,63 +182,25 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
 
     it("should claim local tokens", async () => {
         // 1. we need to setup the Sparse Merkle Tree proofs
-
-        // Local merkle tree
-        const height = 32;
-        const merkleTreeLocal = new MerkleTreeBridge(height);
-
         const originNetworkId = networkId;
         const tokenAddress = token.target;
         const destinationNetworkId = networkId;
         const destinationAddress = alice.address;
         const amount = ethers.parseEther("1.0");
-        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
-
-        const leafValue = getLeafValue(
-            LEAF_TYPE_ASSET,
+        const [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot] = await _setProofs(
             originNetworkId,
-            tokenAddress,
+            tokenAddress as string,
             destinationNetworkId,
             destinationAddress,
             amount,
-            metadataHash
+            tokenMetadata,
+            polygonZkEVMGlobalExitRoot.connect(rollupManager)
         );
-        merkleTreeLocal.add(leafValue);
-        const indexLocal = 0;
-        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
-        const rootLocalRollup = merkleTreeLocal.getRoot();
 
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
-
-        // Rollup merkle tree
-        const merkleTreeRollup = new MerkleTreeBridge(height);
-        for (let i = 0; i < 10; i++) {
-            merkleTreeRollup.add(rootLocalRollup);
-        }
-        const indexRollup = 5;
-        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
-        const rootRollup = merkleTreeRollup.getRoot();
-
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
-
-        // 2. we need to update the exit root
-        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
-        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
-            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
-            .withArgs(lastMainnetExitRoot, rootRollup);
-
-        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
-        expect(lastRollupExitRoot).to.be.equal(rootRollup);
-
-        // 3. we need to calculate the global index
-        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
-
-        // 4. Topup the bridge
+        // 2. Topup the bridge
         await token.mint(polygonZkEVMBridge.target, amount);
 
-        // 5. Alice claim
+        // 3. Alice claim
         const beforeClaim = await token.balanceOf(alice.address);
         await polygonZkEVMBridge.claimAsset(
             proofLocal,
@@ -244,62 +222,23 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
 
     it("should claim non-local tokens with default wrapper", async () => {
         // 1. we need to setup the Sparse Merkle Tree proofs
-
-        // Local merkle tree
-        const height = 32;
-        const merkleTreeLocal = new MerkleTreeBridge(height);
-
         const originNetworkId = networkId + 1; // NOTE: non-local tokens
         const tokenAddress = token.target;
         const destinationNetworkId = networkId;
         const destinationAddress = alice.address;
         const amount = ethers.parseEther("1.0");
-        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
-
-        const leafValue = getLeafValue(
-            LEAF_TYPE_ASSET,
+        const [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot] = await _setProofs(
             originNetworkId,
-            tokenAddress,
+            tokenAddress as string,
             destinationNetworkId,
             destinationAddress,
             amount,
-            metadataHash
+            tokenMetadata,
+            polygonZkEVMGlobalExitRoot.connect(rollupManager)
         );
-        merkleTreeLocal.add(leafValue);
-        const indexLocal = 0;
-        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
-        const rootLocalRollup = merkleTreeLocal.getRoot();
 
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
-
-        // Rollup merkle tree
-        const merkleTreeRollup = new MerkleTreeBridge(height);
-        for (let i = 0; i < 10; i++) {
-            merkleTreeRollup.add(rootLocalRollup);
-        }
-        const indexRollup = 5;
-        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
-        const rootRollup = merkleTreeRollup.getRoot();
-
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
-
-        // 2. we need to update the exit root
-        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
-        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
-            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
-            .withArgs(lastMainnetExitRoot, rootRollup);
-
-        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
-        expect(lastRollupExitRoot).to.be.equal(rootRollup);
-
-        // 3. we need to calculate the global index
-        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
-
-        // 4. we need to get the address of token wrapper
+        // 2. We need to get the address of token wrapper
         const tokenWrappedFactory = await ethers.getContractFactory("TokenWrapped");
-        // create2 parameters
         const salt = ethers.solidityPackedKeccak256(["uint32", "address"], [originNetworkId, tokenAddress]);
         const minimalBytecodeProxy = await polygonZkEVMBridge.BASE_INIT_BYTECODE_WRAPPED_TOKEN();
         const hashInitCode = ethers.solidityPackedKeccak256(["bytes", "bytes"], [minimalBytecodeProxy, tokenMetadata]);
@@ -310,7 +249,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         );
         const defaultWrappedToken = tokenWrappedFactory.attach(precalculateWrappedErc20) as TokenWrapped;
 
-        // 5. Alice claim
+        // 3. Alice claim
         await expect(
             polygonZkEVMBridge.claimAsset(
                 proofLocal,
@@ -336,71 +275,33 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
 
     it("should claim non-local tokens with custom wrapper", async () => {
         // 1. we need to setup the Sparse Merkle Tree proofs
-
-        // Local merkle tree
-        const height = 32;
-        const merkleTreeLocal = new MerkleTreeBridge(height);
-
         const originNetworkId = networkId + 1; // NOTE: non-local tokens
         const tokenAddress = token.target;
         const destinationNetworkId = networkId;
         const destinationAddress = alice.address;
         const amount = ethers.parseEther("1.0");
-        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
-
-        const leafValue = getLeafValue(
-            LEAF_TYPE_ASSET,
+        const [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot] = await _setProofs(
             originNetworkId,
-            tokenAddress,
+            tokenAddress as string,
             destinationNetworkId,
             destinationAddress,
             amount,
-            metadataHash
+            tokenMetadata,
+            polygonZkEVMGlobalExitRoot.connect(rollupManager)
         );
-        merkleTreeLocal.add(leafValue);
-        const indexLocal = 0;
-        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
-        const rootLocalRollup = merkleTreeLocal.getRoot();
 
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
-
-        // Rollup merkle tree
-        const merkleTreeRollup = new MerkleTreeBridge(height);
-        for (let i = 0; i < 10; i++) {
-            merkleTreeRollup.add(rootLocalRollup);
-        }
-        const indexRollup = 5;
-        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
-        const rootRollup = merkleTreeRollup.getRoot();
-
-        // Double check the SMT Proof
-        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
-
-        // 2. we need to update the exit root
-        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
-        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
-            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
-            .withArgs(lastMainnetExitRoot, rootRollup);
-
-        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
-        expect(lastRollupExitRoot).to.be.equal(rootRollup);
-
-        // 3. we need to calculate the global index
-        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
-
-        // 4. we need to deploy existing token and the wrapper
+        // 2. we need to deploy existing token and the wrapper
         const tokenFactory = await ethers.getContractFactory("ERC20ExistingMock");
         const existingToken = await tokenFactory.deploy();
         const wrapperFactory = await ethers.getContractFactory("CustomTokenWrapperMock");
         const customWrapper = await wrapperFactory.deploy(existingToken.target);
 
-        // 5. rollupManager set the custom wrapper
+        // 3. rollupManager set the custom wrapper
         await polygonZkEVMBridge
             .connect(rollupManager)
             .setTokenWrappedAddress(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
 
-        // 5. Alice claim
+        // 4. Alice claim
         await expect(
             polygonZkEVMBridge.claimAsset(
                 proofLocal,
@@ -420,5 +321,219 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
             .withArgs(globalIndex, originNetworkId, tokenAddress, destinationAddress, amount)
             .to.emit(existingToken, "Transfer")
             .withArgs(ethers.ZeroAddress, destinationAddress, amount);
+    });
+
+    it("should bridge gas tokens", async () => {
+        const depositCount = await polygonZkEVMBridge.depositCount();
+        const originNetwork = networkId;
+        const tokenAddress = ethers.ZeroAddress; // Ether
+        const amount = ethers.parseEther("10");
+        const destinationNetworkId = 1;
+        const destinationAddress = deployer.address;
+
+        const metadata = "0x"; // since is ether does not have metadata
+
+        const beforeBridge = await ethers.provider.getBalance(polygonZkEVMBridge.target);
+        await expect(
+            polygonZkEVMBridge.bridgeAsset(destinationNetworkId, destinationAddress, amount, tokenAddress, true, "0x", {
+                value: amount,
+            })
+        )
+            .to.emit(polygonZkEVMBridge, "BridgeEvent")
+            .withArgs(
+                LEAF_TYPE_ASSET,
+                originNetwork,
+                tokenAddress,
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                metadata,
+                depositCount
+            );
+
+        const afterBridge = await ethers.provider.getBalance(polygonZkEVMBridge.target);
+        expect(afterBridge - beforeBridge).eq(amount);
+    });
+
+    it("should bridge non-wrapped tokens", async () => {
+        const depositCount = await polygonZkEVMBridge.depositCount();
+        const originNetwork = networkId;
+        const tokenAddress = token.target;
+        const amount = ethers.parseEther("10");
+        const destinationNetworkId = 1;
+        const destinationAddress = deployer.address;
+        const metadata = tokenMetadata;
+
+        // 1. Mint token to alice
+        await token.mint(alice.address, amount);
+
+        // 2. Alice approve bridge to spend the token
+        await token.connect(alice).approve(polygonZkEVMBridge.target, amount);
+
+        const beforeBridge = await token.balanceOf(polygonZkEVMBridge.target);
+
+        // 3. Alice bridge token
+        await expect(
+            polygonZkEVMBridge
+                .connect(alice)
+                .bridgeAsset(destinationNetworkId, destinationAddress, amount, tokenAddress, true, "0x")
+        )
+            .to.emit(polygonZkEVMBridge, "BridgeEvent")
+            .withArgs(
+                LEAF_TYPE_ASSET,
+                originNetwork,
+                tokenAddress,
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                metadata,
+                depositCount
+            );
+
+        const afterBridge = await token.balanceOf(polygonZkEVMBridge.target);
+        expect(afterBridge - beforeBridge).eq(amount);
+    });
+
+    it("should bridge default wrapped tokens", async () => {
+        // 1. we need to setup the Sparse Merkle Tree proofs
+        const originNetworkId = networkId + 1;
+        let tokenAddress = token.target;
+        let destinationNetworkId = networkId;
+        const destinationAddress = alice.address;
+        const amount = ethers.parseEther("1.0");
+        const [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot] = await _setProofs(
+            originNetworkId,
+            tokenAddress as string,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            tokenMetadata,
+            polygonZkEVMGlobalExitRoot.connect(rollupManager)
+        );
+
+        // 2. we need to get the address of the token wrapper
+        const tokenWrappedFactory = await ethers.getContractFactory("TokenWrapped");
+        const salt = ethers.solidityPackedKeccak256(["uint32", "address"], [originNetworkId, tokenAddress]);
+        const minimalBytecodeProxy = await polygonZkEVMBridge.BASE_INIT_BYTECODE_WRAPPED_TOKEN();
+        const hashInitCode = ethers.solidityPackedKeccak256(["bytes", "bytes"], [minimalBytecodeProxy, tokenMetadata]);
+        const precalculateWrappedErc20 = await ethers.getCreate2Address(
+            polygonZkEVMBridge.target as string,
+            salt,
+            hashInitCode
+        );
+        const defaultWrappedToken = tokenWrappedFactory.attach(precalculateWrappedErc20) as TokenWrapped;
+
+        // 3. Alice claim
+        await polygonZkEVMBridge.claimAsset(
+            proofLocal,
+            proofRollup,
+            globalIndex,
+            lastMainnetExitRoot,
+            lastRollupExitRoot,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            tokenMetadata
+        );
+
+        const depositCount = await polygonZkEVMBridge.depositCount();
+        tokenAddress = defaultWrappedToken.target; // Update with the address of wrapped token
+        destinationNetworkId = networkId + 1;
+        const metadata = tokenMetadata;
+
+        // 4. Alice bridge token or withdraw to original chain
+        await expect(
+            polygonZkEVMBridge
+                .connect(alice)
+                .bridgeAsset(destinationNetworkId, destinationAddress, amount, tokenAddress, true, "0x")
+        )
+            .to.emit(polygonZkEVMBridge, "BridgeEvent")
+            .withArgs(
+                LEAF_TYPE_ASSET,
+                originNetworkId,
+                token.target, // NOTE: Target token should be the original address
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                metadata,
+                depositCount
+            );
+    });
+
+    it("should bridge custom wrapped tokens", async () => {
+        // 1. we need to setup the Sparse Merkle Tree proofs
+        const originNetworkId = networkId + 1;
+        let tokenAddress = token.target;
+        let destinationNetworkId = networkId;
+        const destinationAddress = alice.address;
+        const amount = ethers.parseEther("1.0");
+        const [proofLocal, proofRollup, globalIndex, lastMainnetExitRoot, lastRollupExitRoot] = await _setProofs(
+            originNetworkId,
+            tokenAddress as string,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            tokenMetadata,
+            polygonZkEVMGlobalExitRoot.connect(rollupManager)
+        );
+
+        // 2. we need to deploy existing token and the wrapper
+        const tokenFactory = await ethers.getContractFactory("ERC20ExistingMock");
+        const existingToken = await tokenFactory.deploy();
+        const wrapperFactory = await ethers.getContractFactory("CustomTokenWrapperMock");
+        const customWrapper = await wrapperFactory.deploy(existingToken.target);
+
+        // 3. rollupManager set the custom wrapper
+        await polygonZkEVMBridge
+            .connect(rollupManager)
+            .setTokenWrappedAddress(originNetworkId, tokenAddress, customWrapper.target, existingToken.target);
+
+        // 4. Alice claim
+        await polygonZkEVMBridge.claimAsset(
+            proofLocal,
+            proofRollup,
+            globalIndex,
+            lastMainnetExitRoot,
+            lastRollupExitRoot,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            tokenMetadata
+        );
+
+        const depositCount = await polygonZkEVMBridge.depositCount();
+        tokenAddress = existingToken.target; // Update with the address of existing token
+        destinationNetworkId = networkId + 1;
+        const metadata = ethers.AbiCoder.defaultAbiCoder().encode(
+            ["string", "string", "uint8"],
+            [await existingToken.name(), await existingToken.symbol(), 18]
+        );
+
+        // NOTE: if existing token is not burnable, user must approve custom wrapper contract
+        // first in order to allow the custom wrapper contract to transfer out token from the
+        // user account
+
+        // 4. Alice bridge token or withdraw to original chain
+
+        await expect(
+            polygonZkEVMBridge
+                .connect(alice)
+                .bridgeAsset(destinationNetworkId, destinationAddress, amount, tokenAddress, true, "0x")
+        )
+            .to.emit(polygonZkEVMBridge, "BridgeEvent")
+            .withArgs(
+                LEAF_TYPE_ASSET,
+                originNetworkId,
+                token.target, // NOTE: Target token should be the original address
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                metadata,
+                depositCount
+            );
     });
 });

--- a/test/contractsv2/BridgeV2CustomTokens.test.ts
+++ b/test/contractsv2/BridgeV2CustomTokens.test.ts
@@ -9,7 +9,12 @@ import {
     MTBridge as MerkleTreeBridge,
     mtBridgeUtils,
 } from "@0xpolygonhermez/zkevm-commonjs";
-import {type PolygonZkEVMGlobalExitRootV2, type PolygonZkEVMBridgeV2, ERC20PermitMock} from "../../typechain-types";
+import {
+    type PolygonZkEVMGlobalExitRootV2,
+    type PolygonZkEVMBridgeV2,
+    type ERC20PermitMock,
+    type TokenWrapped,
+} from "../../typechain-types";
 
 const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
 const {verifyMerkleProof, getLeafValue} = mtBridgeUtils;
@@ -34,6 +39,11 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
     let polygonZkEVMBridge: PolygonZkEVMBridgeV2;
     let polygonZkEVMGlobalExitRoot: PolygonZkEVMGlobalExitRootV2;
     let token: ERC20PermitMock;
+
+    const tokenMetadata = ethers.AbiCoder.defaultAbiCoder().encode(
+        ["string", "string", "uint8"],
+        ["Polygon", "POL", 18]
+    );
 
     const networkId = 0;
     const LEAF_TYPE_ASSET = 0;
@@ -87,11 +97,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const destinationNetworkId = networkId;
         const destinationAddress = alice.address;
         const amount = ethers.parseEther("1.0");
-        const metadata = ethers.AbiCoder.defaultAbiCoder().encode(
-            ["string", "string", "uint8"],
-            ["Polygon", "POL", 18]
-        );
-        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [metadata]);
+        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
 
         const leafValue = getLeafValue(
             LEAF_TYPE_ASSET,
@@ -138,13 +144,6 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const bridgeBalance = ethers.parseEther("1.0");
         await setBalance(polygonZkEVMBridge.target.toString(), bridgeBalance);
 
-        // const balance = await ethers.provider.getBalance(polygonZkEVMBridge.target);
-
-        // transfer tokens, then claim
-        // await expect(gasToken.transfer(polygonZkEVMBridge.target, amount))
-        //     .to.emit(gasToken, "Transfer")
-        //     .withArgs(deployer.address, polygonZkEVMBridge.target, amount);
-
         // 5. Alice claim
         const beforeClaim = await ethers.provider.getBalance(alice.address);
         await polygonZkEVMBridge.claimAsset(
@@ -158,7 +157,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
             destinationNetworkId,
             destinationAddress,
             amount,
-            metadata
+            tokenMetadata
         );
         const afterClaim = await ethers.provider.getBalance(alice.address);
         const aliceBalance = afterClaim - beforeClaim;
@@ -177,11 +176,7 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         const destinationNetworkId = networkId;
         const destinationAddress = alice.address;
         const amount = ethers.parseEther("1.0");
-        const metadata = ethers.AbiCoder.defaultAbiCoder().encode(
-            ["string", "string", "uint8"],
-            ["Polygon", "POL", 18]
-        );
-        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [metadata]);
+        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
 
         const leafValue = getLeafValue(
             LEAF_TYPE_ASSET,
@@ -227,13 +222,6 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
         // 4. Topup the bridge
         await token.mint(polygonZkEVMBridge.target, amount);
 
-        // const balance = await ethers.provider.getBalance(polygonZkEVMBridge.target);
-
-        // transfer tokens, then claim
-        // await expect(gasToken.transfer(polygonZkEVMBridge.target, amount))
-        //     .to.emit(gasToken, "Transfer")
-        //     .withArgs(deployer.address, polygonZkEVMBridge.target, amount);
-
         // 5. Alice claim
         const beforeClaim = await token.balanceOf(alice.address);
         await polygonZkEVMBridge.claimAsset(
@@ -247,10 +235,194 @@ describe("PolygonZkEVMBridgeV2: Custom Tokens", () => {
             destinationNetworkId,
             destinationAddress,
             amount,
-            metadata
+            tokenMetadata
         );
         const afterClaim = await token.balanceOf(alice.address);
         const aliceBalance = afterClaim - beforeClaim;
         expect(aliceBalance).eq(amount);
+    });
+
+    it("should claim non-local tokens with default wrapper", async () => {
+        // 1. we need to setup the Sparse Merkle Tree proofs
+
+        // Local merkle tree
+        const height = 32;
+        const merkleTreeLocal = new MerkleTreeBridge(height);
+
+        const originNetworkId = networkId + 1; // NOTE: non-local tokens
+        const tokenAddress = token.target;
+        const destinationNetworkId = networkId;
+        const destinationAddress = alice.address;
+        const amount = ethers.parseEther("1.0");
+        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
+
+        const leafValue = getLeafValue(
+            LEAF_TYPE_ASSET,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            metadataHash
+        );
+        merkleTreeLocal.add(leafValue);
+        const indexLocal = 0;
+        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
+        const rootLocalRollup = merkleTreeLocal.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
+
+        // Rollup merkle tree
+        const merkleTreeRollup = new MerkleTreeBridge(height);
+        for (let i = 0; i < 10; i++) {
+            merkleTreeRollup.add(rootLocalRollup);
+        }
+        const indexRollup = 5;
+        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
+        const rootRollup = merkleTreeRollup.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
+
+        // 2. we need to update the exit root
+        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
+        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
+            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
+            .withArgs(lastMainnetExitRoot, rootRollup);
+
+        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
+        expect(lastRollupExitRoot).to.be.equal(rootRollup);
+
+        // 3. we need to calculate the global index
+        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
+
+        // 4. we need to get the address of token wrapper
+        const tokenWrappedFactory = await ethers.getContractFactory("TokenWrapped");
+        // create2 parameters
+        const salt = ethers.solidityPackedKeccak256(["uint32", "address"], [originNetworkId, tokenAddress]);
+        const minimalBytecodeProxy = await polygonZkEVMBridge.BASE_INIT_BYTECODE_WRAPPED_TOKEN();
+        const hashInitCode = ethers.solidityPackedKeccak256(["bytes", "bytes"], [minimalBytecodeProxy, tokenMetadata]);
+        const precalculateWrappedErc20 = await ethers.getCreate2Address(
+            polygonZkEVMBridge.target as string,
+            salt,
+            hashInitCode
+        );
+        const defaultWrappedToken = tokenWrappedFactory.attach(precalculateWrappedErc20) as TokenWrapped;
+
+        // 5. Alice claim
+        await expect(
+            polygonZkEVMBridge.claimAsset(
+                proofLocal,
+                proofRollup,
+                globalIndex,
+                lastMainnetExitRoot,
+                lastRollupExitRoot,
+                originNetworkId,
+                tokenAddress,
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                tokenMetadata
+            )
+        )
+            .to.emit(polygonZkEVMBridge, "ClaimEvent")
+            .withArgs(globalIndex, originNetworkId, tokenAddress, destinationAddress, amount)
+            .to.emit(polygonZkEVMBridge, "NewWrappedToken")
+            .withArgs(originNetworkId, tokenAddress, precalculateWrappedErc20, tokenMetadata)
+            .to.emit(defaultWrappedToken, "Transfer")
+            .withArgs(ethers.ZeroAddress, destinationAddress, amount);
+    });
+
+    it("should claim non-local tokens with custom wrapper", async () => {
+        // 1. we need to setup the Sparse Merkle Tree proofs
+
+        // Local merkle tree
+        const height = 32;
+        const merkleTreeLocal = new MerkleTreeBridge(height);
+
+        const originNetworkId = networkId + 1; // NOTE: non-local tokens
+        const tokenAddress = token.target;
+        const destinationNetworkId = networkId;
+        const destinationAddress = alice.address;
+        const amount = ethers.parseEther("1.0");
+        const metadataHash = ethers.solidityPackedKeccak256(["bytes"], [tokenMetadata]);
+
+        const leafValue = getLeafValue(
+            LEAF_TYPE_ASSET,
+            originNetworkId,
+            tokenAddress,
+            destinationNetworkId,
+            destinationAddress,
+            amount,
+            metadataHash
+        );
+        merkleTreeLocal.add(leafValue);
+        const indexLocal = 0;
+        const proofLocal = merkleTreeLocal.getProofTreeByIndex(indexLocal);
+        const rootLocalRollup = merkleTreeLocal.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(leafValue, proofLocal, indexLocal, rootLocalRollup)).to.be.equal(true);
+
+        // Rollup merkle tree
+        const merkleTreeRollup = new MerkleTreeBridge(height);
+        for (let i = 0; i < 10; i++) {
+            merkleTreeRollup.add(rootLocalRollup);
+        }
+        const indexRollup = 5;
+        const proofRollup = merkleTreeRollup.getProofTreeByIndex(indexRollup);
+        const rootRollup = merkleTreeRollup.getRoot();
+
+        // Double check the SMT Proof
+        expect(verifyMerkleProof(rootLocalRollup, proofRollup, indexRollup, rootRollup)).to.be.equal(true);
+
+        // 2. we need to update the exit root
+        const lastMainnetExitRoot = await polygonZkEVMGlobalExitRoot.lastMainnetExitRoot();
+        await expect(polygonZkEVMGlobalExitRoot.connect(rollupManager).updateExitRoot(rootRollup))
+            .to.emit(polygonZkEVMGlobalExitRoot, "UpdateL1InfoTree")
+            .withArgs(lastMainnetExitRoot, rootRollup);
+
+        const lastRollupExitRoot = await polygonZkEVMGlobalExitRoot.lastRollupExitRoot();
+        expect(lastRollupExitRoot).to.be.equal(rootRollup);
+
+        // 3. we need to calculate the global index
+        const globalIndex = computeGlobalIndex(indexLocal, indexRollup, false);
+
+        // 4. we need to get the address of token wrapper
+        const tokenWrappedFactory = await ethers.getContractFactory("TokenWrapped");
+        // create2 parameters
+        const salt = ethers.solidityPackedKeccak256(["uint32", "address"], [originNetworkId, tokenAddress]);
+        const minimalBytecodeProxy = await polygonZkEVMBridge.BASE_INIT_BYTECODE_WRAPPED_TOKEN();
+        const hashInitCode = ethers.solidityPackedKeccak256(["bytes", "bytes"], [minimalBytecodeProxy, tokenMetadata]);
+        const precalculateWrappedErc20 = await ethers.getCreate2Address(
+            polygonZkEVMBridge.target as string,
+            salt,
+            hashInitCode
+        );
+        const defaultWrappedToken = tokenWrappedFactory.attach(precalculateWrappedErc20) as TokenWrapped;
+
+        // 5. Alice claim
+        await expect(
+            polygonZkEVMBridge.claimAsset(
+                proofLocal,
+                proofRollup,
+                globalIndex,
+                lastMainnetExitRoot,
+                lastRollupExitRoot,
+                originNetworkId,
+                tokenAddress,
+                destinationNetworkId,
+                destinationAddress,
+                amount,
+                tokenMetadata
+            )
+        )
+            .to.emit(polygonZkEVMBridge, "ClaimEvent")
+            .withArgs(globalIndex, originNetworkId, tokenAddress, destinationAddress, amount)
+            .to.emit(polygonZkEVMBridge, "NewWrappedToken")
+            .withArgs(originNetworkId, tokenAddress, precalculateWrappedErc20, tokenMetadata)
+            .to.emit(defaultWrappedToken, "Transfer")
+            .withArgs(ethers.ZeroAddress, destinationAddress, amount);
     });
 });

--- a/test/contractsv2/BridgeV2GasTokens.test.ts
+++ b/test/contractsv2/BridgeV2GasTokens.test.ts
@@ -99,6 +99,7 @@ describe("PolygonZkEVMBridge Gas tokens tests", () => {
             0, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManager.address,
+            deployer.address, // Deployer as bridge manager
             metadataToken
         );
 
@@ -150,6 +151,7 @@ describe("PolygonZkEVMBridge Gas tokens tests", () => {
                 1, // zero for ether
                 polygonZkEVMGlobalExitRoot.target,
                 rollupManager.address,
+                deployer.address, // Deployer as bridge manager
                 "0x"
             )
         ).to.be.revertedWithCustomError(polygonZkEVMBridgeContract, "GasTokenNetworkMustBeZeroOnEther");

--- a/test/contractsv2/BridgeV2Metadata.test.ts
+++ b/test/contractsv2/BridgeV2Metadata.test.ts
@@ -87,6 +87,7 @@ describe("PolygonZkEVMBridge Contract", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManager.address,
+            deployer.address, // Set deployer as bridge manager
             "0x"
         );
 

--- a/test/contractsv2/BridgeWrappedAddress.test.ts
+++ b/test/contractsv2/BridgeWrappedAddress.test.ts
@@ -66,6 +66,7 @@ describe("PolygonZkEVMBridge Contract", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManager.address,
+            deployer.address, // Set deployer as bridge manager
             "0x"
         );
     });

--- a/test/contractsv2/ClaimCompressor.test.ts
+++ b/test/contractsv2/ClaimCompressor.test.ts
@@ -86,6 +86,7 @@ describe("PolygonZkEVMBridge Contract", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManager.address,
+            deployer.address, // Set deployer as bridge manager
             "0x"
         );
 

--- a/test/contractsv2/PolygonRollupManager.test.ts
+++ b/test/contractsv2/PolygonRollupManager.test.ts
@@ -161,6 +161,7 @@ describe("Polygon Rollup Manager", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManagerContract.target,
+            deployer.address, // Set deployer as bridge manager
             "0x"
         );
 
@@ -351,6 +352,7 @@ describe("Polygon Rollup Manager", () => {
                 chainID,
                 admin.address,
                 trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -359,17 +361,16 @@ describe("Polygon Rollup Manager", () => {
 
         // UNexisting rollupType
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    0,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                0,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeDoesNotExist");
 
         // Obsolete rollup type and test that fails
@@ -379,17 +380,16 @@ describe("Polygon Rollup Manager", () => {
             .withArgs(newRollupTypeID);
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeObsolete");
         await snapshot2.restore();
 
@@ -403,17 +403,16 @@ describe("Polygon Rollup Manager", () => {
         const newSequencedBatch = 1;
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         )
             .to.emit(rollupManagerContract, "CreateNewRollup")
             .withArgs(newCreatedRollupID, newRollupTypeID, newZKEVMAddress, chainID, gasTokenAddress)
@@ -433,21 +432,21 @@ describe("Polygon Rollup Manager", () => {
 
         // Cannot create 2 chains with the same chainID
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "ChainIDAlreadyExist");
 
         const transaction = await newZkEVMContract.generateInitializeTransaction(
             newCreatedRollupID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -461,6 +460,7 @@ describe("Polygon Rollup Manager", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            deployer.address, // Set deployer as bridge manager
             "0x", // empty metadata
         ]);
 
@@ -1075,6 +1075,7 @@ describe("Polygon Rollup Manager", () => {
                 chainID,
                 admin.address,
                 trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -1083,17 +1084,16 @@ describe("Polygon Rollup Manager", () => {
 
         // Unexisting rollupType
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    0,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                0,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeDoesNotExist");
 
         // Obsolete rollup type and test that fails
@@ -1103,17 +1103,16 @@ describe("Polygon Rollup Manager", () => {
             .withArgs(newRollupTypeID);
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeObsolete");
         await snapshot2.restore();
 
@@ -1127,17 +1126,16 @@ describe("Polygon Rollup Manager", () => {
         const newSequencedBatch = 1;
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         )
             .to.emit(rollupManagerContract, "CreateNewRollup")
             .withArgs(newCreatedRollupID, newRollupTypeID, newZKEVMAddress, chainID, gasTokenAddress)
@@ -1157,21 +1155,21 @@ describe("Polygon Rollup Manager", () => {
 
         // Cannot create 2 chains with the same chainID
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "ChainIDAlreadyExist");
 
         const transaction = await newZkEVMContract.generateInitializeTransaction(
             newCreatedRollupID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             gasMetadataToken
@@ -1185,6 +1183,7 @@ describe("Polygon Rollup Manager", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            deployer.address, // Set deployer as bridge manager
             gasMetadataToken,
         ]);
 
@@ -1652,6 +1651,7 @@ describe("Polygon Rollup Manager", () => {
                 chainID,
                 admin.address,
                 trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -1660,17 +1660,16 @@ describe("Polygon Rollup Manager", () => {
 
         // UNexisting rollupType
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    0,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                0,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeDoesNotExist");
 
         // Obsolete rollup type and test that fails
@@ -1680,17 +1679,16 @@ describe("Polygon Rollup Manager", () => {
             .withArgs(newRollupTypeID);
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeObsolete");
         await snapshot2.restore();
 
@@ -1704,17 +1702,16 @@ describe("Polygon Rollup Manager", () => {
         const newSequencedBatch = 1;
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         )
             .to.emit(rollupManagerContract, "CreateNewRollup")
             .withArgs(newCreatedRollupID, newRollupTypeID, newZKEVMAddress, chainID, gasTokenAddress)
@@ -1734,21 +1731,21 @@ describe("Polygon Rollup Manager", () => {
 
         // Cannot create 2 chains with the same chainID
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "ChainIDAlreadyExist");
 
         const transaction = await newZkEVMContract.generateInitializeTransaction(
             newCreatedRollupID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             gasMetadataToken // empty metadata
@@ -1762,6 +1759,7 @@ describe("Polygon Rollup Manager", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            deployer.address, // Set deployer as bridge manager
             gasMetadataToken, // empty metadata
         ]);
 

--- a/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
@@ -198,6 +198,7 @@ describe("Polygon Rollup manager upgraded", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManagerContract.target,
+            admin.address, // admin as bridge manager
             "0x"
         );
 
@@ -453,6 +454,7 @@ describe("Polygon Rollup manager upgraded", () => {
                 chainID2,
                 admin.address,
                 trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -461,17 +463,16 @@ describe("Polygon Rollup manager upgraded", () => {
 
         // UNexisting rollupType
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    0,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                0,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeDoesNotExist");
 
         // Obsolete rollup type and test that fails
@@ -481,17 +482,16 @@ describe("Polygon Rollup manager upgraded", () => {
             .withArgs(newRollupTypeID);
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeObsolete");
         await snapshot2.restore();
 
@@ -505,17 +505,16 @@ describe("Polygon Rollup manager upgraded", () => {
         const newSequencedBatch = 1;
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         )
             .to.emit(rollupManagerContract, "CreateNewRollup")
             .withArgs(newCreatedRollupID, newRollupTypeID, newZKEVMAddress, chainID2, gasTokenAddress)
@@ -535,21 +534,21 @@ describe("Polygon Rollup manager upgraded", () => {
 
         // Cannot create 2 chains with the same chainID
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "ChainIDAlreadyExist");
 
         const transaction = await newZkEVMContract.generateInitializeTransaction(
             newCreatedRollupID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -1160,6 +1159,7 @@ describe("Polygon Rollup manager upgraded", () => {
                 chainID2,
                 admin.address,
                 trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -1168,17 +1168,16 @@ describe("Polygon Rollup manager upgraded", () => {
 
         // UNexisting rollupType
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    0,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                0,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeDoesNotExist");
 
         // Obsolete rollup type and test that fails
@@ -1188,17 +1187,16 @@ describe("Polygon Rollup manager upgraded", () => {
             .withArgs(newRollupTypeID);
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "RollupTypeObsolete");
         await snapshot2.restore();
 
@@ -1212,17 +1210,16 @@ describe("Polygon Rollup manager upgraded", () => {
         const newSequencedBatch = 1;
 
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         )
             .to.emit(rollupManagerContract, "CreateNewRollup")
             .withArgs(newCreatedRollupID, newRollupTypeID, newZKEVMAddress, chainID2, gasTokenAddress)
@@ -1242,21 +1239,21 @@ describe("Polygon Rollup manager upgraded", () => {
 
         // Cannot create 2 chains with the same chainID2
         await expect(
-            rollupManagerContract
-                .connect(admin)
-                .createNewRollup(
-                    newRollupTypeID,
-                    chainID2,
-                    admin.address,
-                    trustedSequencer.address,
-                    gasTokenAddress,
-                    urlSequencer,
-                    networkName
-                )
+            rollupManagerContract.connect(admin).createNewRollup(
+                newRollupTypeID,
+                chainID2,
+                admin.address,
+                trustedSequencer.address,
+                deployer.address, // Set deployer as bridge manager
+                gasTokenAddress,
+                urlSequencer,
+                networkName
+            )
         ).to.be.revertedWithCustomError(rollupManagerContract, "ChainIDAlreadyExist");
 
         const transaction = await newZkEVMContract.generateInitializeTransaction(
             newCreatedRollupID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -1270,6 +1267,7 @@ describe("Polygon Rollup manager upgraded", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            deployer.address, // Set deployer as bridge manager
             "0x",
         ]);
 

--- a/test/contractsv2/PolygonValidiumEtrog.test.ts
+++ b/test/contractsv2/PolygonValidiumEtrog.test.ts
@@ -158,6 +158,7 @@ describe("PolygonZkEVMEtrog", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManagerContract.target,
+            deployer.address, // Set deployer as bridge manager
             "0x"
         );
 
@@ -191,6 +192,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -205,6 +207,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -224,6 +227,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -239,6 +243,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -253,6 +258,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -272,6 +278,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -289,6 +296,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -509,6 +517,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -520,6 +529,7 @@ describe("PolygonZkEVMEtrog", () => {
 
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -665,6 +675,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -681,6 +692,7 @@ describe("PolygonZkEVMEtrog", () => {
 
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -1018,6 +1030,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 newWrappedToken.target,
                 urlSequencer,
                 networkName,
@@ -1029,6 +1042,7 @@ describe("PolygonZkEVMEtrog", () => {
 
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            deployer.address, // Set deployer as bridge manager
             tokenAddress,
             originNetwork,
             metadata // empty metadata
@@ -1086,6 +1100,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -1096,6 +1111,7 @@ describe("PolygonZkEVMEtrog", () => {
         const timestampCreatedRollup = (await ethers.provider.getBlock("latest"))?.timestamp;
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -1258,6 +1274,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -1268,6 +1285,7 @@ describe("PolygonZkEVMEtrog", () => {
         const timestampCreatedRollup = (await ethers.provider.getBlock("latest"))?.timestamp;
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -1371,6 +1389,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -1381,6 +1400,7 @@ describe("PolygonZkEVMEtrog", () => {
         const timestampCreatedRollup = (await ethers.provider.getBlock("latest"))?.timestamp;
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -1473,6 +1493,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                deployer.address, // Set deployer as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -1483,6 +1504,7 @@ describe("PolygonZkEVMEtrog", () => {
         const timestampCreatedRollup = (await ethers.provider.getBlock("latest"))?.timestamp;
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            deployer.address, // Set deployer as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata

--- a/test/contractsv2/PolygonZkEVMEtrog.test.ts
+++ b/test/contractsv2/PolygonZkEVMEtrog.test.ts
@@ -155,6 +155,7 @@ describe("PolygonZkEVMEtrog", () => {
             ethers.ZeroAddress, // zero for ether
             polygonZkEVMGlobalExitRoot.target,
             rollupManagerContract.target,
+            admin.address, // admin as bridge manager
             "0x"
         );
 
@@ -180,6 +181,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName
@@ -194,6 +196,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -213,6 +216,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -230,6 +234,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -330,7 +335,7 @@ describe("PolygonZkEVMEtrog", () => {
     it("should generateInitializeTransaction with huge metadata", async () => {
         const hugeMetadata = `0x${"00".repeat(Number(2n ** 16n))}`;
         await expect(
-            PolygonZKEVMV2Contract.generateInitializeTransaction(0, ethers.ZeroAddress, 1, hugeMetadata)
+            PolygonZKEVMV2Contract.generateInitializeTransaction(0, admin.address, ethers.ZeroAddress, 1, hugeMetadata)
         ).to.be.revertedWithCustomError(PolygonZKEVMV2Contract, "HugeTokenMetadataNotSupported");
     });
     it("should check full flow", async () => {
@@ -342,6 +347,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -352,6 +358,7 @@ describe("PolygonZkEVMEtrog", () => {
 
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            admin.address, // Admin as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -365,6 +372,7 @@ describe("PolygonZkEVMEtrog", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            admin.address, // Admin as bridge manager
             "0x", // empty metadata
         ]);
         const blockCreatedRollup = await ethers.provider.getBlock("latest");
@@ -625,6 +633,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 newWrappedToken.target,
                 urlSequencer,
                 networkName,
@@ -636,6 +645,7 @@ describe("PolygonZkEVMEtrog", () => {
 
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            admin.address, // Admin as bridge manager
             tokenAddress,
             originNetwork,
             metadata // empty metadata
@@ -649,6 +659,7 @@ describe("PolygonZkEVMEtrog", () => {
             originNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            admin.address, // Admin as bridge manager
             metadata, // empty metadata
         ]);
 
@@ -693,6 +704,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -703,6 +715,7 @@ describe("PolygonZkEVMEtrog", () => {
         const timestampCreatedRollup = (await ethers.provider.getBlock("latest"))?.timestamp;
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            admin.address, // Admin as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -716,6 +729,7 @@ describe("PolygonZkEVMEtrog", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            admin.address, // Admin as bridge manager
             "0x", // empty metadata
         ]);
 
@@ -806,6 +820,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -816,6 +831,7 @@ describe("PolygonZkEVMEtrog", () => {
         const timestampCreatedRollup = (await ethers.provider.getBlock("latest"))?.timestamp;
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            admin.address, // Admin as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -829,6 +845,7 @@ describe("PolygonZkEVMEtrog", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            admin.address, // Admin as bridge manager
             "0x", // empty metadata
         ]);
 
@@ -908,6 +925,7 @@ describe("PolygonZkEVMEtrog", () => {
                 admin.address,
                 trustedSequencer.address,
                 networkID,
+                admin.address, // Admin as bridge manager
                 gasTokenAddress,
                 urlSequencer,
                 networkName,
@@ -918,6 +936,7 @@ describe("PolygonZkEVMEtrog", () => {
         const timestampCreatedRollup = (await ethers.provider.getBlock("latest"))?.timestamp;
         const transaction = await PolygonZKEVMV2Contract.generateInitializeTransaction(
             networkID,
+            admin.address, // Admin as bridge manager
             gasTokenAddress,
             gasTokenNetwork,
             "0x" // empty metadata
@@ -931,6 +950,7 @@ describe("PolygonZkEVMEtrog", () => {
             gasTokenNetwork,
             globalExitRootL2Address,
             ethers.ZeroAddress,
+            admin.address, // Admin as bridge manager
             "0x", // empty metadata
         ]);
 


### PR DESCRIPTION
The existing bridge contract is designed to address two specific scenarios:

1. When the `originToken` originates from the current chain, the contract facilitates the transfer of the escrowed token.
2. When the `originToken` originates from a different chain, the contract first deploys a wrapped version of the token and then mints the wrapped token.

A new requirement has emerged, necessitating the bridge contract to recognize an `existingToken` on the current chain that is valued on a 1:1 basis with the `originToken`.

To accommodate this requirement, this pull request introduces a new function to the bridge contract, named `setTokenWrappedAddress`. This function leverages the existing functionalities of the contract to meet the new requirement efficiently.

The `setTokenWrappedAddress` function enables the rollup manager to:
1. Deploy a contract capable of minting and burning the `existingToken`.
2. Designate the deployed contract as the token's wrapper.

It is important to note that:
- The admin has the authority to update the wrapper contract by invoking `setTokenWrappedAddress` again. This flexibility is crucial for accommodating any changes in the minting/burning logic of the token.

## Flow

Suppose we have

1. Chain A - `firstToken`
2. Chain B - `secondToken` (existing token)

### Step 0: Rollup manager deploy custom wrapper for `secondToken`

Rollup manager deploy custom wrapper that have arbitary logic to mint and burn `secondToken`.

### Step 1: Rollup manager executes `setTokenWrappedAddress`

Rollup manager executes `setTokenWrappedAddress` in Chain B with the following parameters:
- `originNetwork` -> Chain A
- `originTokenAddress` -> `firstToken`
- `wrappedTokenAddress` -> Contract from step 0
- `existingTokenAddress` -> `secondToken`

### Step 2: User bridge from chain A

1. User execute `bridgeAsset` in chain A with `firstToken` as input
2. Bridge contract escrow the `firstToken`
3. `claimAsset` is executed on chain B
4. Using `tokenInfoToWrappedToken` mapping, `secondToken` is minted
5. User receives `secondToken`

### Step 3: User withdraw to chain A

1. User execute `bridgeAsset` in chain B with `secondToken` as input
2. Using `wrappedTokenToTokenInfo` and `existingTokenToWrapper` mapping, custom wrapper contract burn the `secondToken`.
3. `claimAsset` is executed on chain A
4. Bridge contract transfers escrowed token
5. User receives `firstToken`

