### PR TITLE
Use the newer go-ethereum Docker image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
     geth:
-        image: ethereum/client-go:v1.12.0
+        image: ethereum/client-go:v1.13.15
         environment:
             - DEV_PERIOD
         ports:


### PR DESCRIPTION
Since the `zkevm-node` recently introduced the L1 Safe Block synchronization feature (https://github.com/0xPolygonHermez/zkevm-node/pull/3545), and is running the synchronizer with `safe` or `finalized` for `Synchronizer.SyncBlockProtection`, `Synchronizer.L1BlockCheck.L1SafeBlockPoint` etc., we should use the newer Geth docker image, in order to overcome the error being returned by some earlier versions of Geth (namely 1.12.x).  This is the PR that fixed it on the go-ethereum (https://github.com/ethereum/go-ethereum/pull/27799), so instead of returning an error when the RPC request with the `safe` or `finalized` option is provided, it defers to the blockchain whether error should be returned or not.