### PR TITLE
mini updates

### DIFF
--- a/contracts/v2/PolygonRollupManager.sol
+++ b/contracts/v2/PolygonRollupManager.sol
@@ -32,11 +32,6 @@ contract PolygonRollupManager is
 {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
-    enum VerifierType {
-        StateTransition,
-        Pessimistic
-    }
-
     /**
      * @notice Struct which to store the rollup type data
      * @param consensusImplementation Consensus implementation ( contains the consensus logic for the transaparent proxy)
@@ -189,7 +184,7 @@ contract PolygonRollupManager is
     mapping(uint32 rollupID => RollupData) public rollupIDToRollupData;
 
     // Rollups address mapping
-    // Pessimistic rollups does not have setted this mapping
+    // NonZkChains does not have setted this mapping
     mapping(address rollupAddress => uint32 rollupID) public rollupAddressToID;
 
     // Chain ID mapping for nullifying
@@ -502,7 +497,7 @@ contract PolygonRollupManager is
      * @param verifier Verifier address, must be added before
      * @param forkID Fork id of the added rollup
      * @param chainID Chain id of the added rollup
-     * @param genesis Genesis block for this rollup
+     * @param initRoot Genesis block for StateTransitionChains & localExitRoot for nonZkChains
      * @param rollupVerifierType Compatibility ID for the added rollup
      * @param programVKey Hashed program that will be executed in case of using a "general porpuse ZK verifier" e.g SP1
      */
@@ -511,7 +506,7 @@ contract PolygonRollupManager is
         address verifier,
         uint64 forkID,
         uint64 chainID,
-        bytes32 genesis,
+        bytes32 initRoot,
         VerifierType rollupVerifierType,
         bytes32 programVKey
     ) external onlyRole(_ADD_EXISTING_ROLLUP_ROLE) {
@@ -550,9 +545,9 @@ contract PolygonRollupManager is
         // Check verifier type
         if (rollupVerifierType == VerifierType.Pessimistic) {
             rollup.programVKey = programVKey;
-            rollup.lastLocalExitRoot = genesis;
+            rollup.lastLocalExitRoot = initRoot;
         } else {
-            rollup.batchNumToStateRoot[0] = genesis;
+            rollup.batchNumToStateRoot[0] = initRoot;
         }
         // rollup type is 0, since it does not follow any rollup type
         emit AddExistingRollup(

--- a/contracts/v2/PolygonRollupManager.sol
+++ b/contracts/v2/PolygonRollupManager.sol
@@ -2,7 +2,6 @@
 
 pragma solidity 0.8.20;
 
-import "./interfaces/IPolygonRollupManager.sol";
 import "./interfaces/IPolygonZkEVMGlobalExitRootV2.sol";
 import "../interfaces/IPolygonZkEVMBridge.sol";
 import "./interfaces/IPolygonRollupBase.sol";
@@ -184,7 +183,6 @@ contract PolygonRollupManager is
     mapping(uint32 rollupID => RollupData) public rollupIDToRollupData;
 
     // Rollups address mapping
-    // NonZkChains does not have setted this mapping
     mapping(address rollupAddress => uint32 rollupID) public rollupAddressToID;
 
     // Chain ID mapping for nullifying
@@ -497,7 +495,7 @@ contract PolygonRollupManager is
      * @param verifier Verifier address, must be added before
      * @param forkID Fork id of the added rollup
      * @param chainID Chain id of the added rollup
-     * @param initRoot Genesis block for StateTransitionChains & localExitRoot for nonZkChains
+     * @param initRoot Genesis block for StateTransitionChains & localExitRoot for pessimistic chain
      * @param rollupVerifierType Compatibility ID for the added rollup
      * @param programVKey Hashed program that will be executed in case of using a "general porpuse ZK verifier" e.g SP1
      */

--- a/contracts/v2/interfaces/IPolygonRollupManager.sol
+++ b/contracts/v2/interfaces/IPolygonRollupManager.sol
@@ -309,7 +309,7 @@ interface IPolygonRollupManager {
 
     function addNewRollupType(
         address consensusImplementation,
-        IVerifierRollup verifier,
+        address verifier,
         uint64 forkID,
         VerifierType rollupVerifierType,
         bytes32 initRoot,
@@ -336,7 +336,7 @@ interface IPolygonRollupManager {
         IVerifierRollup verifier,
         uint64 forkID,
         uint64 chainID,
-        bytes32 genesis,
+        bytes32 initRoot,
         VerifierType rollupVerifierType,
         bytes32 programVKey
     ) external;
@@ -398,6 +398,13 @@ interface IPolygonRollupManager {
     function getBatchFee() external returns (uint256);
 
     function getForcedBatchFee() external returns (uint256);
+
+    function getInputPessimisticBytes(
+        uint32 rollupID,
+        bytes32 selectedGlobalExitRoot,
+        bytes32 newLocalExitRoot,
+        bytes32 newPessimisticRoot
+    ) external returns (bytes memory);
 
     function getInputSnarkBytes(
         uint32 rollupID,

--- a/contracts/v2/interfaces/IPolygonRollupManager.sol
+++ b/contracts/v2/interfaces/IPolygonRollupManager.sol
@@ -2,6 +2,10 @@
 
 pragma solidity ^0.8.20;
 
+import "../../interfaces/IVerifierRollup.sol";
+import "./IPolygonRollupBase.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts5/proxy/transparent/TransparentUpgradeableProxy.sol";
+
 interface IPolygonRollupManager {
     /**
      * @dev Thrown when sender is not the PolygonZkEVM address
@@ -279,11 +283,6 @@ interface IPolygonRollupManager {
     error GlobalExitRootNotExist();
 
     /**
-     * @dev Only Pessimistic Chains
-     */
-    error OnlyPessimisticChains();
-
-    /**
      * @dev Only State Transition Chains
      */
     error OnlyStateTransitionChains();
@@ -302,4 +301,121 @@ interface IPolygonRollupManager {
      * @dev Invalid Pessimistic proof
      */
     error InvalidPessimisticProof();
+
+    enum VerifierType {
+        StateTransition,
+        Pessimistic
+    }
+
+    function addNewRollupType(
+        address consensusImplementation,
+        IVerifierRollup verifier,
+        uint64 forkID,
+        VerifierType rollupVerifierType,
+        bytes32 initRoot,
+        string memory description,
+        bytes32 programVKey
+    ) external;
+
+    function obsoleteRollupType(
+        uint32 rollupTypeID
+    ) external;
+
+    function createNewRollup(
+        uint32 rollupTypeID,
+        uint64 chainID,
+        address admin,
+        address sequencer,
+        address gasTokenAddress,
+        string memory sequencerURL,
+        string memory networkName
+    ) external;
+
+    function addExistingRollup(
+        IPolygonRollupBase rollupAddress,
+        IVerifierRollup verifier,
+        uint64 forkID,
+        uint64 chainID,
+        bytes32 genesis,
+        VerifierType rollupVerifierType,
+        bytes32 programVKey
+    ) external;
+
+    function updateRollupByRollupAdmin(
+        ITransparentUpgradeableProxy rollupContract,
+        uint32 newRollupTypeID
+    ) external;
+
+    function updateRollup(
+        ITransparentUpgradeableProxy rollupContract,
+        uint32 newRollupTypeID,
+        bytes memory upgradeData
+    ) external;
+
+    function rollbackBatches(
+        IPolygonRollupBase rollupContract,
+        uint64 targetBatch
+    ) external;
+
+    function onSequenceBatches(
+        uint64 newSequencedBatches,
+        bytes32 newAccInputHash
+    ) external returns (uint64);
+
+    function verifyBatchesTrustedAggregator(
+        uint32 rollupID,
+        uint64 pendingStateNum,
+        uint64 initNumBatch,
+        uint64 finalNewBatch,
+        bytes32 newLocalExitRoot,
+        bytes32 newStateRoot,
+        address beneficiary,
+        bytes32[24] calldata proof
+    ) external;
+    
+    function verifyPessimisticTrustedAggregator(
+        uint32 rollupID,
+        bytes32 selectedGlobalExitRoot,
+        bytes32 newLocalExitRoot,
+        bytes32 newPessimisticRoot,
+        bytes32[24] calldata proof
+    ) external;
+
+    function activateEmergencyState() external;
+
+    function deactivateEmergencyState() external;
+    
+    function setBatchFee(uint256 newBatchFee) external;
+
+    function getRollupExitRoot() external returns (bytes32);
+
+    function getLastVerifiedBatch(
+        uint32 rollupID
+    ) external returns (uint64);
+
+    function calculateRewardPerBatch() external returns (uint256);
+
+    function getBatchFee() external returns (uint256);
+
+    function getForcedBatchFee() external returns (uint256);
+
+    function getInputSnarkBytes(
+        uint32 rollupID,
+        uint64 initNumBatch,
+        uint64 finalNewBatch,
+        bytes32 newLocalExitRoot,
+        bytes32 oldStateRoot,
+        bytes32 newStateRoot
+    ) external returns (bytes memory);
+
+    function getRollupBatchNumToStateRoot(
+        uint32 rollupID,
+        uint64 batchNum
+    ) external returns (bytes32);
+
+    // function getRollupSequencedBatches(
+    //     uint32 rollupID,
+    //     uint64 batchNum
+    // ) external returns (SequencedBatchData memory);
+
 }

--- a/contracts/v2/lib/PolygonConsensusBase.sol
+++ b/contracts/v2/lib/PolygonConsensusBase.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../../interfaces/IPolygonZkEVMErrors.sol";
 import "../interfaces/IPolygonZkEVMVEtrogErrors.sol";
 import "../interfaces/IPolygonConsensusBase.sol";
-import "../PolygonRollupManager.sol";
+import "../interfaces/IPolygonRollupManager.sol";
 import "../interfaces/IPolygonRollupBase.sol";
 import "../interfaces/IPolygonZkEVMBridgeV2.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
@@ -36,7 +36,7 @@ abstract contract PolygonConsensusBase is
     IPolygonZkEVMBridgeV2 public immutable bridgeAddress;
 
     // Rollup manager
-    PolygonRollupManager public immutable rollupManager;
+    IPolygonRollupManager public immutable rollupManager;
 
     // Address that will be able to adjust contract parameters
     address public admin;
@@ -119,7 +119,7 @@ abstract contract PolygonConsensusBase is
         IPolygonZkEVMGlobalExitRootV2 _globalExitRootManager,
         IERC20Upgradeable _pol,
         IPolygonZkEVMBridgeV2 _bridgeAddress,
-        PolygonRollupManager _rollupManager
+        IPolygonRollupManager _rollupManager
     ) {
         globalExitRootManager = _globalExitRootManager;
         pol = _pol;


### PR DESCRIPTION
 - rename `PessimisticChains` to `NonZkChains`
 - Fix mocks with new implementations (no changes)
 - Fix `rollupManagerNotUpgraded` (no changes)
 - do interface `RollupManager`
 - review delete contants not used since pendingState and Fees are deleted (no changes)
 -`addNewRollupType` --> renaming genesis since it is used in different ways or another param