### PR TITLE
selectedGER to l1infotree

### DIFF
--- a/contracts/v2/PolygonRollupManager.sol
+++ b/contracts/v2/PolygonRollupManager.sol
@@ -851,6 +851,10 @@ contract PolygonRollupManager is
 
         RollupData storage rollup = _rollupIDToRollupData[rollupID];
 
+        if (rollup.rollupVerifierType != VerifierType.StateTransition) {
+            revert OnlyStateTransitionChains();
+        }
+
         // Update total sequence parameters
         totalSequencedBatches += newSequencedBatches;
 
@@ -1018,14 +1022,14 @@ contract PolygonRollupManager is
     /**
      * @notice Allows a trusted aggregator to verify pessimistic proof
      * @param rollupID Rollup identifier
-     * @param selectedGlobalExitRoot Selected global exit root to proof imported bridges
+     * @param l1InfoTreeLeafCount Count of the L1InfoTree leaf that will be used to verify imported bridge exits
      * @param newLocalExitRoot New local exit root
      * @param newPessimisticRoot New pessimistic information, Hash(localBalanceTreeRoot, nullifierTreeRoot)
      * @param proof SP1 proof (Plonk)
      */
     function verifyPessimisticTrustedAggregator(
         uint32 rollupID,
-        bytes32 selectedGlobalExitRoot,
+        uint32 l1InfoTreeLeafCount,
         bytes32 newLocalExitRoot,
         bytes32 newPessimisticRoot,
         bytes calldata proof
@@ -1037,17 +1041,19 @@ contract PolygonRollupManager is
             revert OnlyChainsWithPessimisticProofs();
         }
 
-        // Check selected global exit root exist
-        if (
-            globalExitRootManager.globalExitRootMap(selectedGlobalExitRoot) == 0
-        ) {
-            revert GlobalExitRootNotExist();
+        // Check l1InfoTreeLeafCount has a valid l1InfoTreeRoot
+        bytes32 l1InfoRoot = globalExitRootManager.l1InfoRootMap(
+            l1InfoTreeLeafCount
+        );
+
+        if (l1InfoRoot == bytes32(0)) {
+            revert L1InfoTreeLeafCountInvalid();
         }
 
         bytes memory inputPessimisticBytes = _getInputPessimisticBytes(
             rollupID,
             rollup,
-            selectedGlobalExitRoot,
+            l1InfoRoot,
             newLocalExitRoot,
             newPessimisticRoot
         );
@@ -1277,13 +1283,13 @@ contract PolygonRollupManager is
     /**
      * @notice Function to calculate the pessimistic input bytes
      * @param rollupID Rollup id used to calculate the input snark bytes
-     * @param selectedGlobalExitRoot Selected global exit root to proof imported bridges
+     * @param l1InfoTreeRoot L1 Info tree root to proof imported bridges
      * @param newLocalExitRoot New local exit root
      * @param newPessimisticRoot New pessimistic information, Hash(localBalanceTreeRoot, nullifierTreeRoot)
      */
     function getInputPessimisticBytes(
         uint32 rollupID,
-        bytes32 selectedGlobalExitRoot,
+        bytes32 l1InfoTreeRoot,
         bytes32 newLocalExitRoot,
         bytes32 newPessimisticRoot
     ) public view returns (bytes memory) {
@@ -1291,7 +1297,7 @@ contract PolygonRollupManager is
             _getInputPessimisticBytes(
                 rollupID,
                 _rollupIDToRollupData[rollupID],
-                selectedGlobalExitRoot,
+                l1InfoTreeRoot,
                 newLocalExitRoot,
                 newPessimisticRoot
             );
@@ -1301,14 +1307,14 @@ contract PolygonRollupManager is
      * @notice Function to calculate the input snark bytes
      * @param rollupID Rollup identifier
      * @param rollup Rollup data storage pointer
-     * @param selectedGlobalExitRoot Selected global exit root to proof imported bridges
+     * @param l1InfoTreeRoot L1 Info tree root to proof imported bridges
      * @param newLocalExitRoot New local exit root
      * @param newPessimisticRoot New pessimistic information, Hash(localBalanceTreeRoot, nullifierTreeRoot)
      */
     function _getInputPessimisticBytes(
         uint32 rollupID,
         RollupData storage rollup,
-        bytes32 selectedGlobalExitRoot,
+        bytes32 l1InfoTreeRoot,
         bytes32 newLocalExitRoot,
         bytes32 newPessimisticRoot
     ) internal view returns (bytes memory) {
@@ -1321,7 +1327,7 @@ contract PolygonRollupManager is
             abi.encodePacked(
                 rollup.lastLocalExitRoot,
                 rollup.lastPessimisticRoot,
-                selectedGlobalExitRoot,
+                l1InfoTreeRoot,
                 rollupID,
                 consensusHash,
                 newLocalExitRoot,

--- a/contracts/v2/consensus/validium/PolygonValidiumEtrog.sol
+++ b/contracts/v2/consensus/validium/PolygonValidiumEtrog.sol
@@ -121,7 +121,7 @@ contract PolygonValidiumEtrog is PolygonRollupBaseEtrog, IPolygonValidium {
         );
 
         if (l1InfoRoot == bytes32(0)) {
-            revert L1InfoRootIndexInvalid();
+            revert L1InfoTreeLeafCountInvalid();
         }
 
         // Store storage variables in memory, to save gas, because will be overrided multiple times

--- a/contracts/v2/interfaces/IPolygonRollupManager.sol
+++ b/contracts/v2/interfaces/IPolygonRollupManager.sol
@@ -278,9 +278,9 @@ interface IPolygonRollupManager {
     error InvalidRollup();
 
     /**
-     * @dev Global exit root does not exists
+     * @dev Not valid L1 info tree leaf count
      */
-    error GlobalExitRootNotExist();
+    error L1InfoTreeLeafCountInvalid();
 
     /**
      * @dev Only State Transition Chains
@@ -378,7 +378,7 @@ interface IPolygonRollupManager {
 
     function verifyPessimisticTrustedAggregator(
         uint32 rollupID,
-        bytes32 selectedGlobalExitRoot,
+        uint32 l1InfoTreeLeafCount,
         bytes32 newLocalExitRoot,
         bytes32 newPessimisticRoot,
         bytes calldata proof

--- a/contracts/v2/interfaces/IPolygonZkEVMEtrogErrors.sol
+++ b/contracts/v2/interfaces/IPolygonZkEVMEtrogErrors.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.20;
 import "../../interfaces/IPolygonZkEVMErrors.sol";
 
-interface IPolygonZkEVMVEtrogErrors is IPolygonZkEVMErrors {
+interface IPolygonZkEVMEtrogErrors is IPolygonZkEVMErrors {
     /**
      * @dev Thrown when the caller is not the trusted sequencer
      */

--- a/contracts/v2/interfaces/IPolygonZkEVMEtrogErrors.sol
+++ b/contracts/v2/interfaces/IPolygonZkEVMEtrogErrors.sol
@@ -55,7 +55,7 @@ interface IPolygonZkEVMEtrogErrors is IPolygonZkEVMErrors {
     error MaxTimestampSequenceInvalid();
 
     /**
-     * @dev Thrown when l1 info root does not exist
+     * @dev Thrown when l1 info tree leafCount does not exist
      */
     error L1InfoTreeLeafCountInvalid();
 

--- a/contracts/v2/interfaces/IPolygonZkEVMVEtrogErrors.sol
+++ b/contracts/v2/interfaces/IPolygonZkEVMVEtrogErrors.sol
@@ -57,7 +57,7 @@ interface IPolygonZkEVMVEtrogErrors is IPolygonZkEVMErrors {
     /**
      * @dev Thrown when l1 info root does not exist
      */
-    error L1InfoRootIndexInvalid();
+    error L1InfoTreeLeafCountInvalid();
 
     /**
      * @dev Thrown when the acc input hash does not match the predicted by the sequencer

--- a/contracts/v2/lib/PolygonConsensusBase.sol
+++ b/contracts/v2/lib/PolygonConsensusBase.sol
@@ -125,6 +125,9 @@ abstract contract PolygonConsensusBase is
         pol = _pol;
         bridgeAddress = _bridgeAddress;
         rollupManager = _rollupManager;
+
+        // Disable initalizers on the implementation following the best practices
+        _disableInitializers();
     }
 
     /**

--- a/contracts/v2/lib/PolygonConsensusBase.sol
+++ b/contracts/v2/lib/PolygonConsensusBase.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 import "../interfaces/IPolygonZkEVMGlobalExitRootV2.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../../interfaces/IPolygonZkEVMErrors.sol";
-import "../interfaces/IPolygonZkEVMVEtrogErrors.sol";
+import "../interfaces/IPolygonZkEVMEtrogErrors.sol";
 import "../interfaces/IPolygonConsensusBase.sol";
 import "../interfaces/IPolygonRollupBase.sol";
 import "../interfaces/IPolygonZkEVMBridgeV2.sol";
@@ -24,7 +24,7 @@ import "../PolygonRollupManager.sol";
 abstract contract PolygonConsensusBase is
     Initializable,
     IPolygonConsensusBase,
-    IPolygonZkEVMVEtrogErrors
+    IPolygonZkEVMEtrogErrors
 {
     // POL token address
     IERC20Upgradeable public immutable pol;

--- a/contracts/v2/lib/PolygonRollupBaseEtrog.sol
+++ b/contracts/v2/lib/PolygonRollupBaseEtrog.sol
@@ -354,7 +354,7 @@ abstract contract PolygonRollupBaseEtrog is
         );
 
         if (l1InfoRoot == bytes32(0)) {
-            revert L1InfoRootIndexInvalid();
+            revert L1InfoTreeLeafCountInvalid();
         }
 
         // Store storage variables in memory, to save gas, because will be overrided multiple times

--- a/contracts/v2/lib/PolygonRollupBaseEtrog.sol
+++ b/contracts/v2/lib/PolygonRollupBaseEtrog.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "../interfaces/IPolygonZkEVMGlobalExitRootV2.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../../interfaces/IPolygonZkEVMErrors.sol";
 import "../interfaces/IPolygonZkEVMVEtrogErrors.sol";
 import "../PolygonRollupManager.sol";

--- a/contracts/v2/lib/PolygonRollupBaseEtrog.sol
+++ b/contracts/v2/lib/PolygonRollupBaseEtrog.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "../interfaces/IPolygonZkEVMGlobalExitRootV2.sol";
 import "../../interfaces/IPolygonZkEVMErrors.sol";
-import "../interfaces/IPolygonZkEVMVEtrogErrors.sol";
+import "../interfaces/IPolygonZkEVMEtrogErrors.sol";
 import "../PolygonRollupManager.sol";
 import "../interfaces/IPolygonRollupBase.sol";
 import "../interfaces/IPolygonZkEVMBridgeV2.sol";

--- a/contracts/v2/previousVersions/PolygonRollupBaseEtrogPrevious.sol
+++ b/contracts/v2/previousVersions/PolygonRollupBaseEtrogPrevious.sol
@@ -283,6 +283,9 @@ abstract contract PolygonRollupBaseEtrogPrevious is
         pol = _pol;
         bridgeAddress = _bridgeAddress;
         rollupManager = _rollupManager;
+
+        // Disable initalizers on the implementation following the best practices
+        _disableInitializers();
     }
 
     /**

--- a/contracts/v2/previousVersions/PolygonRollupBaseEtrogPrevious.sol
+++ b/contracts/v2/previousVersions/PolygonRollupBaseEtrogPrevious.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 import "../interfaces/IPolygonZkEVMGlobalExitRootV2.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../../interfaces/IPolygonZkEVMErrors.sol";
-import "../interfaces/IPolygonZkEVMVEtrogErrors.sol";
+import "../interfaces/IPolygonZkEVMEtrogErrors.sol";
 import "../PolygonRollupManager.sol";
 import "./IPolygonRollupBasePrevious.sol";
 import "../interfaces/IPolygonZkEVMBridgeV2.sol";
@@ -23,7 +23,7 @@ import "../lib/PolygonConstantsBase.sol";
 abstract contract PolygonRollupBaseEtrogPrevious is
     Initializable,
     PolygonConstantsBase,
-    IPolygonZkEVMVEtrogErrors,
+    IPolygonZkEVMEtrogErrors,
     IPolygonRollupBasePrevious
 {
     using SafeERC20Upgradeable for IERC20Upgradeable;

--- a/src/pessimistic-utils.js
+++ b/src/pessimistic-utils.js
@@ -17,7 +17,7 @@ const ConsensusTypes = {
  * ) % FrSNARK
  * @param {String} lastLocalExitRoot - old LER
  * @param {String} lastPessimisticRoot - old pessimistic root. pessRoor = Poseidon(LBR # nullifierRoot)
- * @param {String} selectedGlobalExitRoot - selected GER
+ * @param {String} l1InfoTreeRoot - L1 info tree root
  * @param {Number} rollupID - rollup identifier (networkID = rollupID - 1)
  * @param {String} consensusHash - consensus hash. consensusHash = Sha(consensusType # consensusPayload)
  * @param {String} newLocalExitRoot - new LER
@@ -26,7 +26,7 @@ const ConsensusTypes = {
 function computeInputPessimisticBytes(
     lastLocalExitRoot,
     lastPessimisticRoot,
-    selectedGlobalExitRoot,
+    l1InfoTreeRoot,
     rollupID,
     consensusHash,
     newLocalExitRoot,
@@ -37,7 +37,7 @@ function computeInputPessimisticBytes(
         [
             lastLocalExitRoot,
             lastPessimisticRoot,
-            selectedGlobalExitRoot,
+            l1InfoTreeRoot,
             rollupID,
             consensusHash,
             newLocalExitRoot,

--- a/test/contractsv2/PolygonPessimisticConsensus.test.ts
+++ b/test/contractsv2/PolygonPessimisticConsensus.test.ts
@@ -31,12 +31,12 @@ describe("PolygonPessimisticConsensus", () => {
         // deploy consensus
         // create polygonPessimisticConsensus implementation
         const ppConsensusFactory = await ethers.getContractFactory("PolygonPessimisticConsensus");
-        PolygonPPConsensusContract = await ppConsensusFactory.deploy(
-            gerManagerAddress,
-            polTokenAddress,
-            bridgeAddress,
-            rollupManagerAddress
-        );
+        PolygonPPConsensusContract = await upgrades.deployProxy(ppConsensusFactory, [], {
+            initializer: false,
+            constructorArgs: [gerManagerAddress, polTokenAddress, bridgeAddress, rollupManagerAddress],
+            unsafeAllow: ["constructor", "state-variable-immutable"],
+        });
+
         await PolygonPPConsensusContract.waitForDeployment();
     });
 

--- a/test/contractsv2/PolygonRollupManager.test.ts
+++ b/test/contractsv2/PolygonRollupManager.test.ts
@@ -3038,12 +3038,17 @@ describe("Polygon Rollup Manager", () => {
 
         // Create zkEVM implementation
         const PolygonZKEVMV2Factory = await ethers.getContractFactory("PolygonZkEVMExistentEtrog");
-        const PolygonZKEVMV2Contract = await PolygonZKEVMV2Factory.deploy(
-            polygonZkEVMGlobalExitRoot.target,
-            polTokenContract.target,
-            polygonZkEVMBridgeContract.target,
-            rollupManagerContract.target
-        );
+        const PolygonZKEVMV2Contract = await upgrades.deployProxy(PolygonZKEVMV2Factory, [], {
+            initializer: false,
+            constructorArgs: [
+                polygonZkEVMGlobalExitRoot.target,
+                polTokenContract.target,
+                polygonZkEVMBridgeContract.target,
+                rollupManagerContract.target,
+            ],
+            unsafeAllow: ["constructor", "state-variable-immutable"],
+        });
+
         await PolygonZKEVMV2Contract.waitForDeployment();
 
         // Add a new rollup type with timelock

--- a/test/contractsv2/PolygonValidiumEtrog.test.ts
+++ b/test/contractsv2/PolygonValidiumEtrog.test.ts
@@ -29,7 +29,7 @@ function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
     return ethers.solidityPackedKeccak256(["bytes32", "bytes32"], [mainnetExitRoot, rollupExitRoot]);
 }
 
-describe("PolygonZkEVMEtrog", () => {
+describe("PolygonValidiumEtrog", () => {
     let deployer: any;
     let timelock: any;
     let emergencyCouncil: any;
@@ -166,12 +166,17 @@ describe("PolygonZkEVMEtrog", () => {
         // deploy consensus
         // Create zkEVM implementation
         const PolygonZKEVMV2Factory = await ethers.getContractFactory("PolygonValidiumEtrog");
-        PolygonZKEVMV2Contract = await PolygonZKEVMV2Factory.deploy(
-            polygonZkEVMGlobalExitRoot.target,
-            polTokenContract.target,
-            polygonZkEVMBridgeContract.target,
-            rollupManagerContract.target
-        );
+        PolygonZKEVMV2Contract = await upgrades.deployProxy(PolygonZKEVMV2Factory, [], {
+            initializer: false,
+            constructorArgs: [
+                polygonZkEVMGlobalExitRoot.target,
+                polTokenContract.target,
+                polygonZkEVMBridgeContract.target,
+                rollupManagerContract.target,
+            ],
+            unsafeAllow: ["constructor", "state-variable-immutable"],
+        });
+
         await PolygonZKEVMV2Contract.waitForDeployment();
 
         // Create CdkCommitee

--- a/test/contractsv2/PolygonZkEVMEtrog.test.ts
+++ b/test/contractsv2/PolygonZkEVMEtrog.test.ts
@@ -163,12 +163,17 @@ describe("PolygonZkEVMEtrog", () => {
         // deploy consensus
         // Create zkEVM implementation
         const PolygonZKEVMV2Factory = await ethers.getContractFactory("PolygonZkEVMEtrog");
-        PolygonZKEVMV2Contract = await PolygonZKEVMV2Factory.deploy(
-            polygonZkEVMGlobalExitRoot.target,
-            polTokenContract.target,
-            polygonZkEVMBridgeContract.target,
-            rollupManagerContract.target
-        );
+        PolygonZKEVMV2Contract = await upgrades.deployProxy(PolygonZKEVMV2Factory, [], {
+            initializer: false,
+            constructorArgs: [
+                polygonZkEVMGlobalExitRoot.target,
+                polTokenContract.target,
+                polygonZkEVMBridgeContract.target,
+                rollupManagerContract.target,
+            ],
+            unsafeAllow: ["constructor", "state-variable-immutable"],
+        });
+
         await PolygonZKEVMV2Contract.waitForDeployment();
     });
 
@@ -490,7 +495,7 @@ describe("PolygonZkEVMEtrog", () => {
                 expectedAccInputHash,
                 trustedSequencer.address
             )
-        ).to.be.revertedWithCustomError(PolygonZKEVMV2Contract, "L1InfoRootIndexInvalid");
+        ).to.be.revertedWithCustomError(PolygonZKEVMV2Contract, "L1InfoTreeLeafCountInvalid");
 
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(


### PR DESCRIPTION
This PR does the following:
- change PP public from `selectedGER` to `l1InfoTreeRoot`
  - select `l1InfoTreeRoot` via `l1InfoTreeLeafCount`
  - update test
- only allow `transitionChains` to call `onSequenceBatches` as a safety measure
- add `_disableInitializers();` in consensus implementations for best practices
  - update test
- typo `IPolygonZkEVMVEtrogErrors.sol` -->  `IPolygonZkEVMEtrogErrors.sol`