### PR TITLE
rename indexL1 to leafCount

### DIFF
--- a/contracts/v2/consensus/validium/PolygonValidiumEtrog.sol
+++ b/contracts/v2/consensus/validium/PolygonValidiumEtrog.sol
@@ -77,7 +77,7 @@ contract PolygonValidiumEtrog is PolygonRollupBaseEtrog, IPolygonValidium {
     /**
      * @notice Allows a sequencer to send multiple batches
      * @param batches Struct array which holds the necessary data to append new batches to the sequence
-     * @param indexL1InfoRoot Index of the L1InfoRoot that will be used in this sequence
+     * @param l1InfoTreeLeafCount leaf count of the L1InfoRoot that will be used in this sequence
      * @param maxSequenceTimestamp Max timestamp of the sequence. This timestamp must be inside a safety range (actual + 36 seconds).
      * This timestamp should be equal or higher of the last block inside the sequence, otherwise this batch will be invalidated by circuit.
      * @param expectedFinalAccInputHash This parameter must match the acc input hash after hash all the batch data
@@ -90,7 +90,7 @@ contract PolygonValidiumEtrog is PolygonRollupBaseEtrog, IPolygonValidium {
      */
     function sequenceBatchesValidium(
         ValidiumBatchData[] calldata batches,
-        uint32 indexL1InfoRoot,
+        uint32 l1InfoTreeLeafCount,
         uint64 maxSequenceTimestamp,
         bytes32 expectedFinalAccInputHash,
         address l2Coinbase,
@@ -117,7 +117,7 @@ contract PolygonValidiumEtrog is PolygonRollupBaseEtrog, IPolygonValidium {
 
         // Get global batch variables
         bytes32 l1InfoRoot = globalExitRootManager.l1InfoRootMap(
-            indexL1InfoRoot
+            l1InfoTreeLeafCount
         );
 
         if (l1InfoRoot == bytes32(0)) {
@@ -247,7 +247,7 @@ contract PolygonValidiumEtrog is PolygonRollupBaseEtrog, IPolygonValidium {
     /**
      * @notice Allows a sequencer to send multiple batches
      * @param batches Struct array which holds the necessary data to append new batches to the sequence
-     * @param indexL1InfoRoot Index of the L1InfoRoot that will be used in this sequence
+     * @param l1InfoTreeLeafCount Index of the L1InfoRoot that will be used in this sequence
      * @param maxSequenceTimestamp Max timestamp of the sequence. This timestamp must be inside a safety range (actual + 36 seconds).
      * This timestamp should be equal or higher of the last block inside the sequence, otherwise this batch will be invalidated by circuit.
      * @param expectedFinalAccInputHash This parameter must match the acc input hash after hash all the batch data
@@ -257,7 +257,7 @@ contract PolygonValidiumEtrog is PolygonRollupBaseEtrog, IPolygonValidium {
      */
     function sequenceBatches(
         BatchData[] calldata batches,
-        uint32 indexL1InfoRoot,
+        uint32 l1InfoTreeLeafCount,
         uint64 maxSequenceTimestamp,
         bytes32 expectedFinalAccInputHash,
         address l2Coinbase
@@ -267,7 +267,7 @@ contract PolygonValidiumEtrog is PolygonRollupBaseEtrog, IPolygonValidium {
         }
         super.sequenceBatches(
             batches,
-            indexL1InfoRoot,
+            l1InfoTreeLeafCount,
             maxSequenceTimestamp,
             expectedFinalAccInputHash,
             l2Coinbase

--- a/contracts/v2/lib/PolygonRollupBaseEtrog.sol
+++ b/contracts/v2/lib/PolygonRollupBaseEtrog.sol
@@ -402,7 +402,7 @@ abstract contract PolygonRollupBaseEtrog is
     /**
      * @notice Allows a sequencer to send multiple batches
      * @param batches Struct array which holds the necessary data to append new batches to the sequence
-     * @param indexL1InfoRoot Index of the L1InfoRoot that will be used in this sequence
+     * @param l1InfoTreeLeafCount Index of the L1InfoRoot that will be used in this sequence
      * @param maxSequenceTimestamp Max timestamp of the sequence. This timestamp must be inside a safety range (actual + 36 seconds).
      * This timestamp should be equal or higher of the last block inside the sequence, otherwise this batch will be invalidated by circuit.
      * @param expectedFinalAccInputHash This parameter must match the acc input hash after hash all the batch data
@@ -412,7 +412,7 @@ abstract contract PolygonRollupBaseEtrog is
      */
     function sequenceBatches(
         BatchData[] calldata batches,
-        uint32 indexL1InfoRoot,
+        uint32 l1InfoTreeLeafCount,
         uint64 maxSequenceTimestamp,
         bytes32 expectedFinalAccInputHash,
         address l2Coinbase
@@ -438,7 +438,7 @@ abstract contract PolygonRollupBaseEtrog is
 
         // Get global batch variables
         bytes32 l1InfoRoot = globalExitRootManager.l1InfoRootMap(
-            indexL1InfoRoot
+            l1InfoTreeLeafCount
         );
 
         if (l1InfoRoot == bytes32(0)) {

--- a/test/contractsv2/PolygonRollupManager.test.ts
+++ b/test/contractsv2/PolygonRollupManager.test.ts
@@ -555,7 +555,7 @@ describe("Polygon Rollup Manager", () => {
         // Sequence Batches
         const currentTime = Number((await ethers.provider.getBlock("latest"))?.timestamp);
         let currentLastBatchSequenced = 1;
-        const indexL1infoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
 
         const height = 32;
         const merkleTreeGLobalExitRoot = new MerkleTreeBridge(height);
@@ -580,7 +580,7 @@ describe("Polygon Rollup Manager", () => {
                 .connect(trustedSequencer)
                 .sequenceBatches(
                     [sequence],
-                    indexL1infoRoot,
+                    l1InfoTreeLeafCount,
                     currentTime,
                     expectedAccInputHash2,
                     trustedSequencer.address
@@ -921,7 +921,7 @@ describe("Polygon Rollup Manager", () => {
                 .connect(trustedSequencer)
                 .sequenceBatches(
                     [sequenceForced],
-                    indexL1infoRoot,
+                    l1InfoTreeLeafCount,
                     currentTime,
                     expectedAccInputHash3,
                     trustedSequencer.address
@@ -1360,11 +1360,11 @@ describe("Polygon Rollup Manager", () => {
         );
 
         const currentTime = Number((await ethers.provider.getBlock("latest"))?.timestamp);
-        const indexL1InfoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
         const expectedAccInputHash1 = calculateAccInputHashetrog(
             await newZkEVMContract.lastAccInputHash(),
             ethers.keccak256(l2txData),
-            await polygonZkEVMGlobalExitRoot.l1InfoRootMap(indexL1InfoRoot),
+            await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount),
             currentTime,
             trustedSequencer.address,
             ethers.ZeroHash
@@ -1372,7 +1372,13 @@ describe("Polygon Rollup Manager", () => {
         // Sequence Batches
         const txSequenceBatches = await newZkEVMContract
             .connect(trustedSequencer)
-            .sequenceBatches([sequence], indexL1InfoRoot, currentTime, expectedAccInputHash1, trustedSequencer.address);
+            .sequenceBatches(
+                [sequence],
+                l1InfoTreeLeafCount,
+                currentTime,
+                expectedAccInputHash1,
+                trustedSequencer.address
+            );
 
         const receipt = await txSequenceBatches.wait();
         const logs = receipt.logs;
@@ -1971,7 +1977,7 @@ describe("Polygon Rollup Manager", () => {
 
         // Sequence Batches
         const currentTime = Number((await ethers.provider.getBlock("latest"))?.timestamp);
-        const indexL1InfoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
 
         const lastBlock = await ethers.provider.getBlock("latest");
 
@@ -1991,7 +1997,7 @@ describe("Polygon Rollup Manager", () => {
                 .connect(trustedSequencer)
                 .sequenceBatches(
                     [sequence],
-                    indexL1InfoRoot,
+                    l1InfoTreeLeafCount,
                     currentTime,
                     expectedAccInputHash2,
                     trustedSequencer.address
@@ -2650,7 +2656,7 @@ describe("Polygon Rollup Manager", () => {
 
         expect(await newZkEVMContract.dataAvailabilityProtocol()).to.be.equal(PolygonDataCommitee.target);
         await PolygonDataCommitee.setupCommittee(0, [], "0x");
-        const indexL1InfoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
         const lastBlock = await ethers.provider.getBlock("latest");
 
         const rootSC = await polygonZkEVMGlobalExitRoot.getRoot();
@@ -2667,7 +2673,7 @@ describe("Polygon Rollup Manager", () => {
                 .connect(trustedSequencer)
                 .sequenceBatchesValidium(
                     [sequence],
-                    indexL1InfoRoot,
+                    l1InfoTreeLeafCount,
                     currentTime,
                     expectedAccInputHash2,
                     trustedSequencer.address,
@@ -2922,7 +2928,7 @@ describe("Polygon Rollup Manager", () => {
 
         // Sequence Batches
         const currentTime = Number((await ethers.provider.getBlock("latest"))?.timestamp);
-        const indexL1InfoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
         const expectedAccInputHash = calculateAccInputHashetrog(
             await PolygonZKEVMV2Contract.lastAccInputHash(),
             ethers.keccak256(l2txData),
@@ -2934,7 +2940,7 @@ describe("Polygon Rollup Manager", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address

--- a/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
@@ -633,7 +633,7 @@ describe("Polygon Rollup manager upgraded", () => {
         // Sequence Batches
         const currentTime = Number((await ethers.provider.getBlock("latest"))?.timestamp);
         let currentLastBatchSequenced = 1;
-        const indexL1infoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
 
         const height = 32;
         const merkleTreeGLobalExitRoot = new MerkleTreeBridge(height);
@@ -658,7 +658,7 @@ describe("Polygon Rollup manager upgraded", () => {
                 .connect(trustedSequencer)
                 .sequenceBatches(
                     [sequence],
-                    indexL1infoRoot,
+                    l1InfoTreeLeafCount,
                     currentTime,
                     expectedAccInputHash2,
                     trustedSequencer.address
@@ -994,7 +994,7 @@ describe("Polygon Rollup manager upgraded", () => {
                 .connect(trustedSequencer)
                 .sequenceBatches(
                     [sequenceForced],
-                    indexL1infoRoot,
+                    l1InfoTreeLeafCount,
                     currentTime,
                     expectedAccInputHash3,
                     trustedSequencer.address
@@ -1360,7 +1360,7 @@ describe("Polygon Rollup manager upgraded", () => {
 
         const rootSC = await polygonZkEVMGlobalExitRoot.getRoot();
         const rootJS = merkleTreeGLobalExitRoot.getRoot();
-        const indexL1infoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
 
         expect(rootSC).to.be.equal(rootJS);
 
@@ -1378,7 +1378,7 @@ describe("Polygon Rollup manager upgraded", () => {
                 .connect(trustedSequencer)
                 .sequenceBatches(
                     [sequence],
-                    indexL1infoRoot,
+                    l1InfoTreeLeafCount,
                     currentTime,
                     expectedAccInputHash2,
                     trustedSequencer.address

--- a/test/contractsv2/PolygonValidiumEtrog.test.ts
+++ b/test/contractsv2/PolygonValidiumEtrog.test.ts
@@ -578,12 +578,12 @@ describe("PolygonZkEVMEtrog", () => {
         ).to.emit(polTokenContract, "Approval");
 
         // Sequence Batches
-        const indexL1InfoRoot = 0; // No bridges in sequence
+        const l1InfoTreeLeafCount = 0; // No bridges in sequence
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
                 0,
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 expectedAccInputHash,
                 trustedSequencer.address
             )
@@ -601,7 +601,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime + 38,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -611,7 +611,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -621,7 +621,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -638,7 +638,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 hugeBatchArray,
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -656,7 +656,7 @@ describe("PolygonZkEVMEtrog", () => {
                         forcedBlockHashL1: ethers.ZeroHash,
                     },
                 ],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -674,7 +674,7 @@ describe("PolygonZkEVMEtrog", () => {
                         forcedBlockHashL1: ethers.ZeroHash,
                     },
                 ],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -692,7 +692,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash2,
                 trustedSequencer.address
@@ -791,11 +791,11 @@ describe("PolygonZkEVMEtrog", () => {
 
         // Sequence Batches
         const currentTime = Number((await ethers.provider.getBlock("latest"))?.timestamp);
-        const indexL1InfoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
         await expect(
             PolygonZKEVMV2Contract.sequenceBatchesValidium(
                 [sequenceValidium],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address,
@@ -806,7 +806,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatchesValidium(
                 [],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address,
@@ -824,7 +824,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatchesValidium(
                 hugeBatchArray,
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address,
@@ -843,7 +843,7 @@ describe("PolygonZkEVMEtrog", () => {
                         forcedBlockHashL1: ethers.ZeroHash,
                     },
                 ],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address,
@@ -854,7 +854,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatchesValidium(
                 [sequenceValidium],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address,
@@ -916,7 +916,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatchesValidium(
                 [sequenceValidium],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address,
@@ -927,7 +927,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatchesValidium(
                 [sequenceValidium],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address,
@@ -938,7 +938,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatchesValidium(
                 [sequenceValidium],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash2,
                 trustedSequencer.address,
@@ -1317,7 +1317,7 @@ describe("PolygonZkEVMEtrog", () => {
             .withArgs(commiteeHash);
 
         const currentTime = Number((await ethers.provider.getBlock("latest"))?.timestamp);
-        const indexL1InfoRoot = 0;
+        const l1InfoTreeLeafCount = 0;
         const expectedAccInputHash2 = calculateAccInputHashetrog(
             await PolygonZKEVMV2Contract.lastAccInputHash(),
             ethers.keccak256(l2txData),
@@ -1329,7 +1329,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatchesValidium(
                 [sequenceForced],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash2,
                 trustedSequencer.address,

--- a/test/contractsv2/PolygonZkEVMEtrog.test.ts
+++ b/test/contractsv2/PolygonZkEVMEtrog.test.ts
@@ -410,7 +410,7 @@ describe("PolygonZkEVMEtrog", () => {
         ).to.emit(polTokenContract, "Approval");
 
         // Sequence Batches
-        const indexL1InfoRoot = 1;
+        const l1InfoTreeLeafCount = 1;
         // Do one bridge to have first leaf of l1InfoTree with value
         const depositCount = await polygonZkEVMBridgeContract.depositCount();
         const originNetwork = networkIDMainnet;
@@ -475,7 +475,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime + 38,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -495,7 +495,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime + 10,
                 ethers.keccak256(ethers.ZeroHash), // Random expectedAccInputHash
                 trustedSequencer.address
@@ -505,7 +505,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -515,7 +515,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -532,7 +532,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 hugeBatchArray,
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -550,7 +550,7 @@ describe("PolygonZkEVMEtrog", () => {
                         forcedBlockHashL1: ethers.ZeroHash,
                     },
                 ],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -568,7 +568,7 @@ describe("PolygonZkEVMEtrog", () => {
                         forcedBlockHashL1: ethers.ZeroHash,
                     },
                 ],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash,
                 trustedSequencer.address
@@ -578,7 +578,7 @@ describe("PolygonZkEVMEtrog", () => {
         const expectedAccInputHash2 = calculateAccInputHashetrog(
             await PolygonZKEVMV2Contract.lastAccInputHash(),
             ethers.keccak256(l2txData),
-            await polygonZkEVMGlobalExitRoot.l1InfoRootMap(indexL1InfoRoot),
+            await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount),
             currentTime,
             trustedSequencer.address,
             ethers.ZeroHash
@@ -586,7 +586,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash2,
                 trustedSequencer.address
@@ -603,7 +603,7 @@ describe("PolygonZkEVMEtrog", () => {
             expectedAccInputHash3 = calculateAccInputHashetrog(
                 expectedAccInputHash3,
                 ethers.keccak256(l2txData),
-                await polygonZkEVMGlobalExitRoot.l1InfoRootMap(indexL1InfoRoot),
+                await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount),
                 currentTime,
                 trustedSequencer.address,
                 ethers.ZeroHash
@@ -613,7 +613,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 sequenceArray,
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash3,
                 trustedSequencer.address
@@ -623,7 +623,7 @@ describe("PolygonZkEVMEtrog", () => {
         const expectedAccInputHash4 = calculateAccInputHashetrog(
             expectedAccInputHash3,
             ethers.keccak256(l2txData),
-            await polygonZkEVMGlobalExitRoot.l1InfoRootMap(indexL1InfoRoot),
+            await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount),
             currentTime,
             trustedSequencer.address,
             ethers.ZeroHash
@@ -631,7 +631,7 @@ describe("PolygonZkEVMEtrog", () => {
         await expect(
             PolygonZKEVMV2Contract.connect(trustedSequencer).sequenceBatches(
                 [sequence],
-                indexL1InfoRoot,
+                l1InfoTreeLeafCount,
                 currentTime,
                 expectedAccInputHash4,
                 trustedSequencer.address


### PR DESCRIPTION
This PR does the following:
- rename `indexL1InfoRoot` to `l1InfoTreeLeafCount`