### PR TITLE
disable initializer=false

### DIFF
--- a/deployment/v2/3_deployContracts.ts
+++ b/deployment/v2/3_deployContracts.ts
@@ -342,7 +342,6 @@ async function main() {
         for (let i = 0; i < attemptsDeployProxy; i++) {
             try {
                 polygonZkEVMGlobalExitRoot = await upgrades.deployProxy(PolygonZkEVMGlobalExitRootFactory, [], {
-                    initializer: false,
                     constructorArgs: [precalculateRollupManager, proxyBridgeAddress],
                     unsafeAllow: ["constructor", "state-variable-immutable"],
                 });


### PR DESCRIPTION
This PR does the following:
- removes `initializer: false` in deployment scripts to call `initialize()` function automatically in `polygonZkEVMGlobalExitRoot` SC