### PR TITLE
fix: anvil deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@openzeppelin/contracts-upgradeable": "4.8.2",
                 "@openzeppelin/contracts5": "npm:@openzeppelin/contracts@^5.0.0",
                 "@openzeppelin/hardhat-upgrades": "2.5.0",
+                "@openzeppelin/upgrades-core": "1.3",
                 "@types/yargs": "^17.0.28",
                 "circomlibjs": "0.1.1",
                 "dotenv": "^8.6.0",
@@ -3207,6 +3208,27 @@
                 }
             }
         },
+        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/@openzeppelin/upgrades-core": {
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.40.0.tgz",
+            "integrity": "sha512-4bPSXdEqHsNRL5T1ybPLneWGYjzGl6XWGWkv7aUoFFgz8mOdarstRBX1Wi4XJFw6IeHPUI7mMSQr2jdz8Y2ypQ==",
+            "dev": true,
+            "dependencies": {
+                "@nomicfoundation/slang": "^0.17.0",
+                "cbor": "^9.0.0",
+                "chalk": "^4.1.0",
+                "compare-versions": "^6.0.0",
+                "debug": "^4.1.1",
+                "ethereumjs-util": "^7.0.3",
+                "minimatch": "^9.0.5",
+                "minimist": "^1.2.7",
+                "proper-lockfile": "^4.1.1",
+                "solidity-ast": "^0.4.51"
+            },
+            "bin": {
+                "openzeppelin-upgrades-core": "dist/cli/cli.js"
+            }
+        },
         "node_modules/@openzeppelin/hardhat-upgrades/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3220,6 +3242,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/cbor": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
+            "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+            "dev": true,
+            "dependencies": {
+                "nofilter": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/@openzeppelin/hardhat-upgrades/node_modules/chalk": {
@@ -3256,6 +3290,12 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "node_modules/@openzeppelin/hardhat-upgrades/node_modules/compare-versions": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "dev": true
+        },
         "node_modules/@openzeppelin/hardhat-upgrades/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3278,24 +3318,21 @@
             }
         },
         "node_modules/@openzeppelin/upgrades-core": {
-            "version": "1.38.0",
-            "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.38.0.tgz",
-            "integrity": "sha512-0kbc6Wd6S8/Kmhg7oqRIn+GBpAL+EccYQh+SjgVBEktpkzTDN56KHuuxYHXnpXclWaO6l7u/TRMe6LsHCHqJHw==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.3.1.tgz",
+            "integrity": "sha512-wdF++wE0K5GqhyM4fX732B99XqgGebbol28jhWgsG9cTFplxSzqqjxhgyMWRRik+KSPqBSIZZ4PF65knlQx0vg==",
             "dev": true,
             "dependencies": {
-                "@nomicfoundation/slang": "^0.17.0",
-                "cbor": "^9.0.0",
+                "bn.js": "^5.1.2",
+                "cbor": "^5.0.2",
                 "chalk": "^4.1.0",
-                "compare-versions": "^6.0.0",
+                "compare-versions": "^3.6.0",
                 "debug": "^4.1.1",
                 "ethereumjs-util": "^7.0.3",
-                "minimatch": "^9.0.5",
-                "minimist": "^1.2.7",
+                "fp-ts": "^2.7.1",
+                "io-ts": "^2.2.9",
                 "proper-lockfile": "^4.1.1",
-                "solidity-ast": "^0.4.51"
-            },
-            "bin": {
-                "openzeppelin-upgrades-core": "dist/cli/cli.js"
+                "solidity-ast": "^0.4.4"
             }
         },
         "node_modules/@openzeppelin/upgrades-core/node_modules/ansi-styles": {
@@ -3314,15 +3351,16 @@
             }
         },
         "node_modules/@openzeppelin/upgrades-core/node_modules/cbor": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
-            "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+            "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
             "dev": true,
             "dependencies": {
-                "nofilter": "^3.1.0"
+                "bignumber.js": "^9.0.1",
+                "nofilter": "^1.0.4"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=6.0.0"
             }
         },
         "node_modules/@openzeppelin/upgrades-core/node_modules/chalk": {
@@ -3359,10 +3397,34 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "node_modules/@openzeppelin/upgrades-core/node_modules/fp-ts": {
+            "version": "2.16.9",
+            "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.9.tgz",
+            "integrity": "sha512-+I2+FnVB+tVaxcYyQkHUq7ZdKScaBlX53A41mxQtpIccsfyv8PzdzP7fzp2AY832T4aoK6UZ5WRX/ebGd8uZuQ==",
+            "dev": true
+        },
         "node_modules/@openzeppelin/upgrades-core/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@openzeppelin/upgrades-core/node_modules/io-ts": {
+            "version": "2.2.21",
+            "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.21.tgz",
+            "integrity": "sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==",
+            "dev": true,
+            "peerDependencies": {
+                "fp-ts": "^2.5.0"
+            }
+        },
+        "node_modules/@openzeppelin/upgrades-core/node_modules/nofilter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+            "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -4711,6 +4773,15 @@
             "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
             "dev": true
         },
+        "node_modules/bignumber.js": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+            "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5427,9 +5498,9 @@
             "dev": true
         },
         "node_modules/compare-versions": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+            "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
             "dev": true
         },
         "node_modules/concat-map": {
@@ -17389,7 +17460,8 @@
             "version": "0.2.7",
             "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
             "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/hmac-drbg": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@openzeppelin/contracts-upgradeable": "4.8.2",
         "@openzeppelin/contracts5": "npm:@openzeppelin/contracts@^5.0.0",
         "@openzeppelin/hardhat-upgrades": "2.5.0",
+        "@openzeppelin/upgrades-core": "1.3",
         "@types/yargs": "^17.0.28",
         "circomlibjs": "0.1.1",
         "dotenv": "^8.6.0",


### PR DESCRIPTION
## Description

Fix an issue when deploying zkevm-contracts to an anvil node.

![image](https://github.com/user-attachments/assets/07e8b298-3353-47c0-86da-b369ca35cf16)

Related to https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/943

```bash
git clone https://github.com/0xPolygonHermez/zkevm-contracts /tmp/zkevm-contracts
pushd /tmp/zkevm-contracts
git checkout develop

sudo su
docker run --interactive --tty --volume /tmp/zkevm-contracts:/tmp --rm node:16.20-bullseye bash
# inside the container
pushd /tmp
npm install --save-dev @openzeppelin/upgrades-core@1.32.2
# push the changes to package*.json
```