### PR TITLE
Use `unchecked` in DepositContract.sol

### DIFF
--- a/contracts/lib/DepositContract.sol
+++ b/contracts/lib/DepositContract.sol
@@ -71,17 +71,19 @@ contract DepositContract is ReentrancyGuardUpgradeable {
         }
 
         // Add deposit data root to Merkle tree (update a single `_branch` node)
-        uint256 size = ++depositCount;
-        for (
-            uint256 height = 0;
-            height < _DEPOSIT_CONTRACT_TREE_DEPTH;
-            height++
-        ) {
-            if (((size >> height) & 1) == 1) {
-                _branch[height] = node;
-                return;
+        unchecked {
+            uint256 size = ++depositCount;
+            for (
+                uint256 height = 0;
+                height < _DEPOSIT_CONTRACT_TREE_DEPTH;
+                height++
+            ) {
+                if (((size >> height) & 1) == 1) {
+                    _branch[height] = node;
+                    return;
+                }
+                node = keccak256(abi.encodePacked(_branch[height], node));
             }
-            node = keccak256(abi.encodePacked(_branch[height], node));
         }
         // As the loop should always end prematurely with the `return` statement,
         // this code should be unreachable. We assert `false` just to be safe.


### PR DESCRIPTION
Use `unchecked` in the `_deposit` function to skip Solidity's built-in overflow checks for the `++depositCount` operation since the preceding condition  `(if (depositCount >= _MAX_DEPOSIT_COUNT))`
already ensures that an overflow is impossible. This eliminates unnecessary runtime checks, reducing gas costs.