### PR TITLE
fix typos in documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zkevm-contracts
 
-Smart contract implementation which will be used by the polygon zkevm
+Smart contract implementation which will be used by the Polygon zkEVM
 
 [![Main CI](https://github.com/0xPolygonHermez/zkevm-contracts/actions/workflows/main.yml/badge.svg)](https://github.com/0xPolygonHermez/zkevm-contracts/actions/workflows/main.yml)
 
@@ -75,9 +75,9 @@ In order to test, the following private keys are being used. These keys are not 
 
 To verify that the smartcontracts of this repository are the same deployed on mainnet, you could follow the instructions described [document](verifyMainnetDeployment/verifyDeployment.md)
 
-The smartcontract used to verify a proof, it's a generated contract from zkEVM Rom and Pil (constraints). To verify the deployment of this smartcontract you could follow the instructions described in this [document](verifyMainnetDeployment/verifyMainnetProofVerifier.md)
+The smartcontract used to verify a proof, it's a generated contract from zkEVM ROM and PIL (constraints). To verify the deployment of this smartcontract you could follow the instructions described in this [document](verifyMainnetDeployment/verifyMainnetProofVerifier.md)
 
-## Activate github hook
+## Activate GitHub hook
 
 ```
 git config --local core.hooksPath .githooks/

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ By default the following mnemonic will be used to deploy the smart contracts `MN
 Also the first 20 accounts of this mnemonic will be funded with ether.
 The first account of the mnemonic will be the deployer of the smart contracts and therefore the holder of all the MATIC test tokens, which are necessary to pay the `sendBatch` transactions.
 You can change the deployment `mnemonic` creating a `.env` file in the project root with the following variable:
-`MNEMONIC=<YOUR_MENMONIC>`
+`MNEMONIC=<YOUR_MNEMONIC>`
 
 ## Requirements
 


### PR DESCRIPTION
Changes:
polygon zkevm → Polygon zkEVM
zkEVM Rom and Pil → zkEVM ROM and PIL
github → GitHub
YOUR_MENMONIC → YOUR_MNEMONIC

I hope these fixes help improve the documentation, and I’m looking forward to being a useful contributor to the project. Let me know if I can assist with anything else!

