### PR TITLE
docs: Fix Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In order to test, the following private keys are being used. These keys are not 
 
 # Verify Deployed Smart Contracts
 
-To verify that the smartcontracts of this repository are the same deployed on mainnet, you could follow the instructions described [document](verifyMainnetDeployment/verifyDeployment.md)
+To verify that the smartcontracts of this repository are the same deployed on mainnet, you could follow the instructions described in the [document](verifyMainnetDeployment/verifyDeployment.md)
 
 The smartcontract used to verify a proof, it's a generated contract from zkEVM Rom and Pil (constraints). To verify the deployment of this smartcontract you could follow the instructions described in this [document](verifyMainnetDeployment/verifyMainnetProofVerifier.md)
 


### PR DESCRIPTION
I noticed a typo in the "Verify Deployed Smart Contracts" section of the documentation. The sentence previously read:  

> "you could follow the instructions described document"  

It looks like the article "in the" was missing before "document." I've updated it to:  

> "you could follow the instructions described in the document"  

This change should improve clarity and readability for anyone referencing this part of the documentation. 