### PR TITLE
refactor(ClaimCompressor): implement dynamic gas limit for bridge calls

### DIFF
--- a/contracts/v2/utils/ClaimCompressor.sol
+++ b/contracts/v2/utils/ClaimCompressor.sol
@@ -520,9 +520,14 @@ contract ClaimCompressor {
                     revert(0, 0)
                 }
 
-                // SHould i limit the gas TODO of the call
+                // Calculate dynamic gas limit based on remaining gas
+                let gasLimit := div(gas(), 2) // Use half of remaining gas, but not more than 2M
+                if gt(gasLimit, 2000000) {
+                    gasLimit := 2000000
+                }
+
                 let success := call(
-                    2000000, // gas // TODO gas Limited to 2M, could be better to check if it's created the token or not and limit later
+                    gasLimit, // Dynamic gas limit instead of fixed 2M
                     bridgeAddress, // address
                     0, // value
                     0, // args offset


### PR DESCRIPTION
Replace hard-coded 2M gas limit with dynamic gas allocation in ClaimCompressor.sol.
The gas limit is now calculated as half of the remaining gas, capped at 2M.
This change improves gas efficiency while maintaining safety limits.

- Removes TODO comment
- Adds dynamic gas calculation
- Maintains 2M gas upper limit
- Prevents potential out-of-gas scenarios