### PR TITLE
minor improvements genesis sovereign tool

### DIFF
--- a/tools/createSovereignGenesis/README.md
+++ b/tools/createSovereignGenesis/README.md
@@ -45,6 +45,8 @@ cp ./tools/createSovereignGenesis/genesis-base.json.example ./tools/createSovere
   - `setTimelockParameters`: indicates if the timelock parameters are going to be changed
     - `timelockParameters.adminAddress`: address that will have all timelocks roles (ADMIN, PROPOSER, CANCELLER, EXECUTOR)
     - `timelockParameters.minDelay`: minimum delay set in the timelock smart contract
+- Optional parameters
+  - `format`: choose genesis output format. Supported ones: `geth`
 
 -  Run tool:
 ```

--- a/tools/createSovereignGenesis/create-genesis-sovereign-params.json.example
+++ b/tools/createSovereignGenesis/create-genesis-sovereign-params.json.example
@@ -8,11 +8,17 @@
     "sovereignWETHAddressIsNotMintable": false,
     "globalExitRootUpdater": "0x8576158a89648aA88B6036f47B8b74Fc0C2b5c66",
     "globalExitRootRemover": "0x8576158a89648aA88B6036f47B8b74Fc0C2b5c66",
-    "setPreMintAccount": true,
-    "preMintAccount": {
-        "balance": "1000000000000000000",
-        "address": "0x8576158a89648aA88B6036f47B8b74Fc0C2b5c66"
-    },
+    "setPreMintAccounts": true,
+    "preMintAccounts": [
+        {
+            "balance": "1000000000000000000",
+            "address": "0x8576158a89648aA88B6036f47B8b74Fc0C2b5c66"
+        },
+        {
+            "balance": "1000000000000000000",
+            "address": "0xb420EAAbFeFA05b39dE520f811325A463E023954"
+        },
+    ],
     "setTimelockParameters": true,
     "timelockParameters": {
         "adminAddress": "0x8576158a89648aA88B6036f47B8b74Fc0C2b5c66",

--- a/tools/createSovereignGenesis/create-genesis-sovereign-params.json.example
+++ b/tools/createSovereignGenesis/create-genesis-sovereign-params.json.example
@@ -17,5 +17,6 @@
     "timelockParameters": {
         "adminAddress": "0x8576158a89648aA88B6036f47B8b74Fc0C2b5c66",
         "minDelay": 3600
-    }
+    },
+    "formatGenesis": "geth"
 }

--- a/tools/createSovereignGenesis/create-sovereign-genesis.ts
+++ b/tools/createSovereignGenesis/create-sovereign-genesis.ts
@@ -204,6 +204,11 @@ async function main() {
         });
 
         if (typeof preMintAccountExist !== 'undefined') {
+            if (preMintAccountExist.bytecode !== undefined) {
+                logger.error('preMintAccount code is not empty');
+                throw new Error('preMintAccount code is not empty');
+
+            }
             preMintAccountExist.balance = BigInt(createGenesisSovereignParams.preMintAccount.balance).toString();
         } else {
             // add preMintAccount.address & preMintAccount.balance

--- a/tools/createSovereignGenesis/create-sovereign-genesis.ts
+++ b/tools/createSovereignGenesis/create-sovereign-genesis.ts
@@ -212,7 +212,7 @@ async function main() {
 
             // check if preMintAccount is in the current genesis
             const preMintAccountExist = finalGenesis.genesis.find(function (obj) {
-                return obj.address === preMintAccount.address;
+                return obj.address.toLowerCase() === preMintAccount.address.toLowerCase();
             });
 
             if (typeof preMintAccountExist !== 'undefined') {

--- a/tools/createSovereignGenesis/create-sovereign-genesis.ts
+++ b/tools/createSovereignGenesis/create-sovereign-genesis.ts
@@ -269,6 +269,14 @@ async function main() {
     // update genesis root
     finalGenesis.root = smtUtils.h4toString(zkEVMDB.getCurrentStateRoot());
 
+    // extract all namde <--> address from genesis
+    const genesisSCNames = finalGenesis.genesis.reduce((acc: any, obj: any) => {
+        if (obj.bytecode !== undefined) {
+            acc[obj.contractName] = obj.address;
+        }
+        return acc;
+    }, {});
+
     // format genesis
     if (createGenesisSovereignParams.formatGenesis !== undefined) {
         logger.info(`Formatting genesis output to: ${createGenesisSovereignParams.formatGenesis}`);
@@ -290,6 +298,7 @@ async function main() {
     outputJson.sovereignWETHAddressIsNotMintable = createGenesisSovereignParams.sovereignWETHAddressIsNotMintable;
     outputJson.globalExitRootUpdater = createGenesisSovereignParams.globalExitRootUpdater;
     outputJson.globalExitRootRemover = createGenesisSovereignParams.globalExitRootRemover;
+    outputJson.genesisSCNames = genesisSCNames;
 
     if (createGenesisSovereignParams.setPreMintAccounts === true) {
         outputJson.preMintAccounts = createGenesisSovereignParams.preMintAccounts;

--- a/tools/createSovereignGenesis/helpers.ts
+++ b/tools/createSovereignGenesis/helpers.ts
@@ -1,3 +1,5 @@
+import { execSync } from "child_process";
+
 /**
  * Format genesis file to a specific format
  * @param genesis original legacy genesis file
@@ -42,8 +44,6 @@ function _formatGeth(genesis: { genesis: any[]; }) {
     }, {});
 }
 
-import { execSync } from "child_process";
-
 /**
  * Retrieves the current Git commit hash and repository URL
  * @returns An object containing the commit hash and repository URL, or null if an error occurs
@@ -60,7 +60,7 @@ function getGitInfo(): { commit: string; repo: string } | null {
     } catch (error) {
         throw new Error(`getGitInfo: ${error}`);
     }
-  }
+}
 
 module.exports = {
     formatGenesis,

--- a/tools/createSovereignGenesis/helpers.ts
+++ b/tools/createSovereignGenesis/helpers.ts
@@ -1,5 +1,3 @@
-const formatOutputs = ["geth"];
-
 /**
  * Format genesis file to a specific format
  * @param genesis original legacy genesis file
@@ -22,12 +20,24 @@ function formatGenesis(genesis: { genesis: any[]; }, format: any){
  */
 function _formatGeth(genesis: { genesis: any[]; }) {
     return genesis.genesis.reduce((acc, contract) => {
-        acc[contract.address] = {
-            "code": contract.bytecode,
-            "storage": contract.storage,
-            "balance": `0x${BigInt(contract.balance).toString(16)}`,
-            "nonce": `0x${BigInt(contract.nonce).toString(16)}`
-        };
+        acc[contract.address] = {};
+
+        if (contract.bytecode !== undefined) {
+            acc[contract.address].code = contract.bytecode;
+        }
+
+        if (contract.storage !== undefined) {
+            acc[contract.address].storage = contract.storage;
+        }
+
+        if (contract.balance !== undefined) {
+            acc[contract.address].balance = `0x${BigInt(contract.balance).toString(16)}`;
+        }
+
+        if (contract.nonce !== undefined) {
+            acc[contract.address].nonce = `0x${BigInt(contract.nonce).toString(16)}`;
+        }
+
         return acc;
     }, {});
 }

--- a/tools/createSovereignGenesis/helpers.ts
+++ b/tools/createSovereignGenesis/helpers.ts
@@ -1,0 +1,58 @@
+const formatOutputs = ["geth"];
+
+/**
+ * Format genesis file to a specific format
+ * @param genesis original legacy genesis file
+ * @param format Format type
+ * @returns new genesis format
+ */
+function formatGenesis(genesis: { genesis: any[]; }, format: any){
+    switch (format) {
+        case "geth":
+            return _formatGeth(genesis);
+        default:
+            throw new Error(`formatGenesis: unknown format: ${format}`);
+    }
+}
+
+/**
+ * Format legacy genesis file to geth format
+ * @param genesis legacy genesis file
+ * @returns Geth genesis format
+ */
+function _formatGeth(genesis: { genesis: any[]; }) {
+    return genesis.genesis.reduce((acc, contract) => {
+        acc[contract.address] = {
+            "code": contract.bytecode,
+            "storage": contract.storage,
+            "balance": `0x${BigInt(contract.balance).toString(16)}`,
+            "nonce": `0x${BigInt(contract.nonce).toString(16)}`
+        };
+        return acc;
+    }, {});
+}
+
+import { execSync } from "child_process";
+
+/**
+ * Retrieves the current Git commit hash and repository URL
+ * @returns An object containing the commit hash and repository URL, or null if an error occurs
+ */
+function getGitInfo(): { commit: string; repo: string } | null {
+    try {
+      // Get the latest commit hash
+      const commit = execSync("git rev-parse HEAD").toString().trim();
+
+      // Get the repository URL
+      const repo = execSync("git config --get remote.origin.url").toString().trim();
+
+      return { commit, repo };
+    } catch (error) {
+        throw new Error(`getGitInfo: ${error}`);
+    }
+  }
+
+module.exports = {
+    formatGenesis,
+    getGitInfo,
+};

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -3,6 +3,7 @@
 const ethers = require('ethers');
 
 const supportedBridgeContracts = ['PolygonZkEVMBridgeV2 proxy', 'PolygonZkEVMBridge proxy', 'BridgeL2SovereignChain proxy'];
+
 function genOperation(target, value, data, predecessor, salt) {
     const abiEncoded = ethers.AbiCoder.defaultAbiCoder().encode(
         ['address', 'uint256', 'bytes', 'uint256', 'bytes32'],
@@ -51,9 +52,30 @@ function convertBigIntsToNumbers(obj) {
     return obj; // Return the value if it's not a BigInt, object, or array
 }
 
+function checkBridgeAddress(genesis, expectedBridgeAddress){
+    // get bridge address in genesis file
+    let genesisBridgeAddress = ethers.ZeroAddress;
+    let bridgeContractName = "";
+
+    for (let i = 0; i < genesis.genesis.length; i++) {
+        if (supportedBridgeContracts.includes(genesis.genesis[i].contractName)) {
+            genesisBridgeAddress = genesis.genesis[i].address;
+            bridgeContractName = genesis.genesis[i].contractName;
+            break;
+        }
+    }
+
+    if (expectedBridgeAddress.toLowerCase() !== genesisBridgeAddress.toLowerCase()) {
+        throw new Error(
+            `checkBridgeAddress: '${bridgeContractName}' address in the 'genesis.json' does not match the 'expectedBridgeAddress'`
+        );
+    }
+}
+
 module.exports = {
     genOperation,
     transactionTypes,
     convertBigIntsToNumbers,
     supportedBridgeContracts,
+    checkBridgeAddress,
 };


### PR DESCRIPTION
This PR does the following:
- On the tooling `createSovereignGenesis`
  - fix issue when adding balance to an existing account using `preMintAcocunt`
  - adds format genesis output (`geth` format supported)
  - add git information on the output 
  - support multiple `preMintedAccounts`
  - add simple mapping on `output` --> `address <--> SC Name`
  - add basic L1 ifnormation from `RollupManager`
    - polygonBridgeAddress
    - polygonZkEVMGlobalExitRootAddress
    - polygonRollupManagerAddress
    - polygonZkEVMAddress (rollup address)
    - polTokenAddress 