### PR TITLE
fix: add parentheses in _setAndCheckClaimed condition

### DIFF
--- a/contracts/PolygonZkEVMBridge.sol
+++ b/contracts/PolygonZkEVMBridge.sol
@@ -642,7 +642,7 @@ contract PolygonZkEVMBridge is
         (uint256 wordPos, uint256 bitPos) = _bitmapPositions(index);
         uint256 mask = 1 << bitPos;
         uint256 flipped = claimedBitMap[wordPos] ^= mask;
-        if (flipped & mask == 0) {
+        if ((flipped & mask) == 0) {
             revert AlreadyClaimed();
         }
     }


### PR DESCRIPTION
title: fix: add parentheses in _setAndCheckClaimed condition

description: Fixed operator precedence issue in _setAndCheckClaimed function by adding parentheses around bitwise AND operation. The original condition `if (flipped & mask == 0)` was incorrectly evaluating as `if (flipped & (mask == 0))` due to `==` having higher precedence than `&`. Added parentheses to fix the evaluation order: `if ((flipped & mask) == 0)`. This ensures proper checking of claimed indices in the bridge contract.