### PR TITLE
ci: migrate workflows to checkout v4

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,7 +22,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Setup docker
               run: |
                   npm i

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -27,7 +27,7 @@ jobs:
                   eval "$(ssh-agent -s)"
                   ssh-add /tmp/ssh-key
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: setup
               run: |
                   eval "$(ssh-agent -s)"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -23,7 +23,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: setup
               run: npm i
             - name: linter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: setup
               run: npm i
             - name: linter


### PR DESCRIPTION
GitHub-hosted runners now use Node 20, so actions/checkout@v4 is required. Workflows only updated—no functional changes.

Reopen: https://github.com/0xPolygonHermez/zkevm-contracts/pull/435