### PR TITLE
minor changes on LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Polygon zkEVM Mainnet Beta 
-Copyright (C) 2023 Catenable AG 
+Copyright (C) 2023 PT Services DMCC
 
   This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published 

--- a/README.md
+++ b/README.md
@@ -82,3 +82,6 @@ The smartcontract used to verify a proof, it's a generated contract from zkEVM R
 ```
 git config --local core.hooksPath .githooks/
 ```
+
+------
+License: This codebase is licensed under the GNU Affero General Public License (AGPL).  See: [LICENSE](./LICENSE).


### PR DESCRIPTION
This pull request includes updates to the licensing information in the project. The most important changes involve updating the copyright holder in the `LICENSE` file and adding a license notice to the `README.md` file.

Licensing updates:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L2-R2): Updated the copyright holder from "Catenable AG" to "PT Services DMCC."
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R85-R87): Added a license notice specifying that the codebase is licensed under the GNU Affero General Public License (AGPL), with a link to the `LICENSE` file.