### PR TITLE
fix informationals

### DIFF
--- a/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
+++ b/contracts/v2/sovereignChains/BridgeL2SovereignChain.sol
@@ -39,7 +39,7 @@ contract BridgeL2SovereignChain is
     // newUnsetGlobalIndexHashChain = Keccak256(oldUnsetGlobalIndexHashChain,bytes32(removedGlobalIndex));
     bytes32 public unsetGlobalIndexHashChain;
 
-    // Map to store wrappedAddresses that are not mintable
+    // Local balance tree mapping
     mapping(bytes32 tokenInfoHash => uint256 amount) public localBalanceTree;
 
     /// @dev Deprecated in favor of _initializerVersion at PolygonZkEVMBridgeV2
@@ -157,14 +157,6 @@ contract BridgeL2SovereignChain is
     event UpdatedUnsetGlobalIndexHashChain(
         bytes32 unsetGlobalIndex,
         bytes32 newUnsetGlobalIndexHashChain
-    );
-
-    /**
-     * @dev Emitted when the localBalanceTree amount is initialized
-     */
-    event SetInitialLocalBalanceTreeAmount(
-        bytes32 tokenInfoHash,
-        uint256 amount
     );
 
     /**


### PR DESCRIPTION
This pull request updates the `BridgeL2SovereignChain` contract in `contracts/v2/sovereignChains/BridgeL2SovereignChain.sol` by modifying the local balance tree mapping and removing a deprecated event. These changes streamline the contract and reflect updated functionality.

Contract updates:

* Replaced the comment describing the `localBalanceTree` mapping to clarify its purpose as "Local balance tree mapping."
* Removed the `SetInitialLocalBalanceTreeAmount` event, which was used for initializing the local balance tree amount, as it is no longer required.