### PR TITLE
all global owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # global owner
-*       @invocamanman
-
-# src owners
-/contracts/   @invocamanman @krlosMata @ignasirv @laisolizq
+*       @invocamanman @krlosMata @ignasirv @laisolizq


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, consolidating the ownership assignment so that all files are now owned by the full team instead of just a single member.