### PR TITLE
deployOutpost: delete not used example params

### DIFF
--- a/tools/deployOutpostChain/deploy_parameters.json.example
+++ b/tools/deployOutpostChain/deploy_parameters.json.example
@@ -13,8 +13,6 @@
     },
     "bridge": {
         "bridgeManager": "0xYourBridgeManagerAddress",
-        "sovereignWETHAddress": "0x0000000000000000000000000000000000000000",
-        "sovereignWETHAddressIsNotMintable": false,
         "emergencyBridgePauser": "0xYourEmergencyPauserAddress",
         "emergencyBridgeUnpauser": "0xYourEmergencyUnpauserAddress"
     },


### PR DESCRIPTION
This pull request makes a small change to the `deploy_parameters.json.example` file, specifically simplifying the configuration for the bridge by removing two parameters related to the sovereign WETH address.

* Removed `sovereignWETHAddress` and `sovereignWETHAddressIsNotMintable` from the `bridge` configuration in `tools/deployOutpostChain/deploy_parameters.json.example`.