### PR TITLE
Draft proof aggregation

### DIFF
--- a/contracts/AgglayerGateway.sol
+++ b/contracts/AgglayerGateway.sol
@@ -285,8 +285,6 @@ contract AgglayerGateway is
 
         route.frozen = true;
 
-        // TODO: Unsure if reuse old event RouteFrozen or create new one
-        // ProofAggregationRouteFrozen.
         emit ProofAggregationRouteFrozen(
             proofAggregationVKeySelector,
             route.verifier,

--- a/contracts/AgglayerGateway.sol
+++ b/contracts/AgglayerGateway.sol
@@ -28,12 +28,16 @@ contract AgglayerGateway is
     bytes32 internal constant AGGCHAIN_DEFAULT_VKEY_ROLE =
         keccak256("AGGCHAIN_DEFAULT_VKEY_ROLE");
 
-    // Can add a route to a pessimistic verification key.
+    // Can add a route to a pessimistic verification key and an aggregation verification key.
+    // @notice Notice the naming. It's named PP since this role was initially defined for the pessimistic
+    // routes. Later on, the aggregation route was introduced, but we keep the old name to avoid breaking changes.
     // @dev value 0x0fdc2a718b96bc741c7544001e3dd7c26730802c54781668fa78a120e622629b
     bytes32 internal constant AL_ADD_PP_ROUTE_ROLE =
         keccak256("AL_ADD_PP_ROUTE_ROLE");
 
-    // Can freeze a route to a pessimistic verification key.
+    // Can add a route to a pessimistic verification key and an aggregation verification key.
+    // @notice Notice the naming. It's named PP since this role was initially defined for the pessimistic
+    // routes. Later on, the aggregation route was introduced, but we keep the old name to avoid breaking changes.
     // @dev value 0xca75ae4228cde6195f9fa3dbde8dc352fb30aa63780717a378ccfc50274355dd
     bytes32 internal constant AL_FREEZE_PP_ROUTE_ROLE =
         keccak256("AL_FREEZE_PP_ROUTE_ROLE");
@@ -43,7 +47,7 @@ contract AgglayerGateway is
     bytes32 internal constant AL_MULTISIG_ROLE = keccak256("AL_MULTISIG_ROLE");
 
     // Current AgglayerGateway version
-    string public constant AGGLAYER_GATEWAY_VERSION = "v1.1.0";
+    string public constant AGGLAYER_GATEWAY_VERSION = "v2.0.0";
 
     // Maximum number of aggchain signers supported
     uint256 public constant MAX_AGGCHAIN_SIGNERS = 255;
@@ -62,9 +66,11 @@ contract AgglayerGateway is
     mapping(bytes4 defaultAggchainSelector => bytes32 defaultAggchainVKey)
         public defaultAggchainVKeys;
 
-    // Mapping with the pessimistic verification key routes
-    mapping(bytes4 pessimisticVKeySelector => AggLayerVerifierRoute)
-        public pessimisticVKeyRoutes;
+    // Mapping with the aggregation verification key routes. This storage slot was used for the PP
+    // routes in the previous version, but since that's deprecated, we reuse it for the aggregation routes.
+    /// @custom:oz-renamed-from pessimisticVKeyRoutes
+    mapping(bytes4 selector => AggLayerVerifierRoute)
+        public aggregationVKeySelector;
 
     ////////////////////////////////////////////////////////////
     //                      Multisig                          //
@@ -121,9 +127,9 @@ contract AgglayerGateway is
      * @param aggchainDefaultVKeyRole The address that can manage the aggchain verification keys.
      * @param addRouteRole The address that can add a route to a pessimistic verification key.
      * @param freezeRouteRole The address that can freeze a route to a pessimistic verification key.
-     * @param pessimisticVKeySelector The 4 bytes selector to add to the pessimistic verification keys.
+     * @param proofAggregationVKeySelector The 4 bytes selector to add to the proof aggregation verification keys.
      * @param verifier The address of the verifier contract.
-     * @param pessimisticVKey New pessimistic program verification key.
+     * @param proofAggregationVKey New proof aggregation verification key.
      * @param multisigRole The address that can manage multisig signers and threshold.
      * @param signersToAdd Array of signers to add with their URLs
      * @param newThreshold New threshold value
@@ -133,9 +139,9 @@ contract AgglayerGateway is
         address aggchainDefaultVKeyRole,
         address addRouteRole,
         address freezeRouteRole,
-        bytes4 pessimisticVKeySelector,
+        bytes4 proofAggregationVKeySelector,
         address verifier,
-        bytes32 pessimisticVKey,
+        bytes32 proofAggregationVKey,
         address multisigRole,
         SignerInfo[] memory signersToAdd,
         uint256 newThreshold
@@ -160,10 +166,10 @@ contract AgglayerGateway is
         _grantRole(AL_FREEZE_PP_ROUTE_ROLE, freezeRouteRole);
         _grantRole(AL_MULTISIG_ROLE, multisigRole);
 
-        _addPessimisticVKeyRoute(
-            pessimisticVKeySelector,
+        _addProofAggregationVKeyRoute(
+            proofAggregationVKeySelector,
             verifier,
-            pessimisticVKey
+            proofAggregationVKey
         );
 
         // Add the signers to the contract
@@ -174,49 +180,22 @@ contract AgglayerGateway is
         );
     }
 
-    /**
-     * @notice Upgrade initializer to add multisig functionality to existing deployment.
-     * @param multisigRole The address of the multisig role. Can manage multisig signers and threshold.
-     * @param signersToAdd Array of signers to add with their URLs
-     * @param newThreshold New threshold value
-     */
-    function initialize(
-        address multisigRole,
-        SignerInfo[] memory signersToAdd,
-        uint256 newThreshold
-    ) external getInitializedVersion reinitializer(2) {
-        if (_initializerVersion != 1) {
-            revert InvalidInitializer();
-        }
-
-        if (multisigRole == address(0)) {
-            revert InvalidZeroAddress();
-        }
-
-        _grantRole(AL_MULTISIG_ROLE, multisigRole);
-
-        // Add the signers to the contract
-        _updateSignersAndThreshold(
-            new RemoveSignerInfo[](0), // No signers to remove
-            signersToAdd,
-            newThreshold
-        );
-    }
 
     ////////////////////////////////////////////////////////////
-    //        Functions: AgglayerGateway (pessimistic)        //
+    //        Functions: AgglayerGateway (aggregation)        //
     ////////////////////////////////////////////////////////////
+
     /**
-     * @notice Function to verify the pessimistic proof.
-     * @param publicValues Public values of the proof.
-     * @param proofBytes Proof for the pessimistic verification.
-     * @dev First 4 bytes of the pessimistic proof are the pp selector.
-     * proof[0:4]: 4 bytes selector pp
+     * @notice Function to verify an aggregated proof.
+     * @param aggregationPublicValues The aggregation public values encoded as bytes.
+     * @param proofBytes Proof for the pessimistic verification. The first 4 bytes of
+     * proofBytes are the selector.
+     * proof[0:4]: 4 bytes selector for the aggregation vkey
      * proof[4:8]: 4 bytes selector SP1 verifier
      * proof[8:]: proof
      */
-    function verifyPessimisticProof(
-        bytes calldata publicValues,
+    function verifyAggregatedProof(
+        bytes calldata aggregationPublicValues,
         bytes calldata proofBytes
     ) external view {
         /// @dev By protocol the proof should at least have the 4 bytes selector, the other bytes are not part of our protocol
@@ -224,98 +203,95 @@ contract AgglayerGateway is
             revert InvalidProofBytesLength();
         }
 
-        bytes4 ppSelector = bytes4(proofBytes[:4]);
+        bytes4 proofAggregationVKeySelector = bytes4(proofBytes[:4]);
 
-        AggLayerVerifierRoute memory route = pessimisticVKeyRoutes[ppSelector];
+        AggLayerVerifierRoute memory route = aggregationVKeySelector[proofAggregationVKeySelector];
         if (route.verifier == address(0)) {
-            revert RouteNotFound(ppSelector);
+            revert RouteNotFound(proofAggregationVKeySelector);
         } else if (route.frozen) {
-            revert RouteIsFrozen(ppSelector);
+            revert RouteIsFrozen(proofAggregationVKeySelector);
         }
 
         ISP1Verifier(route.verifier).verifyProof(
-            route.pessimisticVKey,
-            publicValues,
+            route.aggregationVKey,
+            aggregationPublicValues,
             proofBytes[4:]
         );
     }
 
     /**
-     * @notice Internal function to add a pessimistic verification key route
-     * @param pessimisticVKeySelector The 4 bytes selector to add to the pessimistic verification keys.
+     * @notice Internal function to add a proof aggregation verification key route
+     * @param proofAggregationVKeySelector The 4 bytes selector to add to the proof aggregation verification keys.
      * @param verifier The address of the verifier contract.
-     * @param pessimisticVKey New pessimistic program verification key
+     * @param proofAggregationVKey New proof aggregation verification key
      */
-    function _addPessimisticVKeyRoute(
-        bytes4 pessimisticVKeySelector,
+    function _addProofAggregationVKeyRoute(
+        bytes4 proofAggregationVKeySelector,
         address verifier,
-        bytes32 pessimisticVKey
+        bytes32 proofAggregationVKey
     ) internal {
         if (verifier == address(0)) {
             revert InvalidZeroAddress();
         }
 
-        if (pessimisticVKeySelector == bytes4(0)) {
-            revert PPSelectorCannotBeZero();
+        if (proofAggregationVKeySelector == bytes4(0)) {
+            revert ProofAggregationVKeySelectorCannotBeZero();
         }
-        if (pessimisticVKey == bytes32(0)) {
+        if (proofAggregationVKey == bytes32(0)) {
             revert VKeyCannotBeZero();
         }
 
-        AggLayerVerifierRoute storage route = pessimisticVKeyRoutes[
-            pessimisticVKeySelector
-        ];
+        AggLayerVerifierRoute storage route = aggregationVKeySelector[proofAggregationVKeySelector];
         if (route.verifier != address(0)) {
-            revert RouteAlreadyExists(pessimisticVKeySelector, route.verifier);
+            revert RouteAlreadyExists(proofAggregationVKeySelector, route.verifier);
         }
 
         route.verifier = verifier;
-        route.pessimisticVKey = pessimisticVKey;
-        emit RouteAdded(pessimisticVKeySelector, verifier, pessimisticVKey);
+        route.aggregationVKey = proofAggregationVKey;
+        emit ProofAggregationRouteAdded(proofAggregationVKeySelector, verifier, proofAggregationVKey);
     }
 
     /**
-     * @notice Function to add a pessimistic verification key route
-     * @param pessimisticVKeySelector The 4 bytes selector to add to the pessimistic verification keys.
+     * @notice Function to add a proof aggregation verification key route
+     * @param proofAggregationVKeySelector The 4 bytes selector to add to the proof aggregation verification keys.
      * @param verifier The address of the verifier contract.
-     * @param pessimisticVKey New pessimistic program verification key
+     * @param proofAggregationVKey New proof aggregation verification key
      */
-    function addPessimisticVKeyRoute(
-        bytes4 pessimisticVKeySelector,
+    function addProofAggregationVKeyRoute(
+        bytes4 proofAggregationVKeySelector,
         address verifier,
-        bytes32 pessimisticVKey
+        bytes32 proofAggregationVKey
     ) external onlyRole(AL_ADD_PP_ROUTE_ROLE) {
-        _addPessimisticVKeyRoute(
-            pessimisticVKeySelector,
+        _addProofAggregationVKeyRoute(
+            proofAggregationVKeySelector,
             verifier,
-            pessimisticVKey
-        );
+            proofAggregationVKey);
     }
 
     /**
-     * @notice Function to freeze a pessimistic verification key route
-     * @param pessimisticVKeySelector The 4 bytes selector to freeze the pessimistic verification key route.
+     * @notice Function to freeze a proof aggregation verification key route
+     * @param proofAggregationVKeySelector The 4 bytes selector to freeze the proof aggregation verification key route.
      */
-    function freezePessimisticVKeyRoute(
-        bytes4 pessimisticVKeySelector
+    function freezeProofAggregationVKeyRoute(
+        bytes4 proofAggregationVKeySelector
     ) external onlyRole(AL_FREEZE_PP_ROUTE_ROLE) {
-        AggLayerVerifierRoute storage route = pessimisticVKeyRoutes[
-            pessimisticVKeySelector
-        ];
+        AggLayerVerifierRoute storage route = aggregationVKeySelector[proofAggregationVKeySelector];
         if (route.verifier == address(0)) {
-            revert RouteNotFound(pessimisticVKeySelector);
+            revert RouteNotFound(proofAggregationVKeySelector);
         }
         if (route.frozen) {
-            revert RouteIsAlreadyFrozen(pessimisticVKeySelector);
+            revert RouteIsAlreadyFrozen(proofAggregationVKeySelector);
         }
 
         route.frozen = true;
 
-        emit RouteFrozen(
-            pessimisticVKeySelector,
+        // TODO: Unsure if reuse old event RouteFrozen or create new one
+        // ProofAggregationRouteFrozen.
+        emit ProofAggregationRouteFrozen(
+            proofAggregationVKeySelector,
             route.verifier,
-            route.pessimisticVKey
-        );
+            route.aggregationVKey
+            );
     }
 
     ////////////////////////////////////////////////////////////

--- a/contracts/AgglayerManager.sol
+++ b/contracts/AgglayerManager.sol
@@ -168,6 +168,20 @@ contract AgglayerManager is
         bytes32 programVKey;
     }
 
+    /**
+     * @notice Struct representing a pessimistic proof state transition.
+     * @param rollupID Chain ID of the rollup
+     * @param newLocalExitRoot New local exit root
+     * @param newPessimisticRoot New pessimistic root
+     * @param aggchainData Aggchain data
+     */
+    struct PessimisticProofInput {
+        uint32 rollupID;
+        bytes32 newLocalExitRoot;
+        bytes32 newPessimisticRoot;
+        bytes aggchainData;
+    }
+
     // Modulus zkSNARK
     uint256 internal constant _RFIELD =
         21888242871839275222246405745257275088548364400416034343698204186575808495617;
@@ -318,6 +332,9 @@ contract AgglayerManager is
     // Mapping to track chains in migration
     mapping(uint32 rollupID => bool) public isRollupMigrating;
 
+    // Last Agglayer Rollup Exit Root
+    bytes32 public lastAgglayerRollupExitRoot;
+
     /**
      * @dev Emitted when a new rollup type is added
      */
@@ -429,6 +446,16 @@ contract AgglayerManager is
         bytes32 newLocalExitRoot,
         bytes32 l1InfoRoot,
         address indexed trustedAggregator
+    );
+
+    /**
+     * @notice Emitted when an aggregated proof verifying multiple aggchains is verified
+     * @param prevArer Previous Agglayer Rollup Exit Root before the state transition
+     * @param newArer New Agglayer Rollup Exit Root after the state transition
+     */
+    event VerifyAggregatedProof(
+        bytes32 indexed prevArer,
+        bytes32 indexed newArer
     );
 
     /**
@@ -1276,39 +1303,101 @@ contract AgglayerManager is
     }
 
     /**
-     * @notice Allows a trusted aggregator to verify pessimistic proof
-     * @param rollupID Rollup identifier
-     * @param l1InfoTreeLeafCount Count of the L1InfoTree leaf that will be used to verify imported bridge exits
-     * @param newLocalExitRoot New local exit root
-     * @param newPessimisticRoot New pessimistic information, Hash(localBalanceTreeRoot, nullifierTreeRoot)
-     * @param proof SP1 proof (Plonk)
-     * @param aggchainData Specific custom data to verify Aggregation layer chains
-     * @dev A reentrancy measure has been applied because this function calls `onVerifyPessimistic`, is an open function implemented by the aggchains
-     * @dev the function can not be a view because the nonReentrant uses a transient storage variable
+     * @notice Allows a trusted aggregator to verify an aggregated proof, which validates the state transition
+     * of multiple aggchains at once.
+     * @param pessimisticProofInputs Array of pessimistic proof inputs verified by the proof
+     * @param l1InfoRoot L1 info tree root
+     * @param newArer New Agglayer Rollup Exit Root
+     * @param proofBytes Aggregated proof containing a SP1 proof (Plonk) validating the state transition of multiple
+     * aggchains at once. The first 4 bytes of the proofBytes are the selector.
      */
-    function verifyPessimisticTrustedAggregator(
-        uint32 rollupID,
-        uint32 l1InfoTreeLeafCount,
-        bytes32 newLocalExitRoot,
-        bytes32 newPessimisticRoot,
-        bytes calldata proof,
-        bytes calldata aggchainData
+    function verifyAggregatedProofTrusted(
+        PessimisticProofInput[] calldata pessimisticProofInputs,
+        bytes32 l1InfoRoot,
+        bytes32 newArer,
+        bytes calldata proofBytes
     ) external onlyRole(_TRUSTED_AGGREGATOR_ROLE) nonReentrant {
-        RollupData storage rollup = _rollupIDToRollupData[rollupID];
+        bytes32 hashChainLeafPubValues = bytes32(0);
 
-        // Not for state transition chains
-        if (rollup.rollupVerifierType == VerifierType.StateTransition) {
-            revert StateTransitionChainsNotAllowed();
+        for (uint256 i = 0; i < pessimisticProofInputs.length; i++) {
+            PessimisticProofInput calldata proofData = pessimisticProofInputs[i];
+            uint32 rollupID = proofData.rollupID;
+            RollupData storage rollup = _rollupIDToRollupData[rollupID];
+
+            if (rollup.rollupVerifierType != VerifierType.ALGateway) {
+                revert InvalidRollupType();
+            }
+
+            bytes32 aggchainHash = IAggchainBase(rollup.rollupContract)
+                .getAggchainHash(proofData.aggchainData);
+
+            // TODO: Point to the code once its released (now its a prototype branch)
+            // https://github.com/agglayer/agglayer/blob/sandbox/aggregation_with_preconf/crates/aggregation-proof-core/src/lib.rs#L106-L116
+            bytes memory leafPubValues = abi.encodePacked(
+                rollupID,
+                rollup.lastLocalExitRoot,
+                proofData.newLocalExitRoot,
+                rollup.lastPessimisticRoot,
+                proofData.newPessimisticRoot,
+                aggchainHash
+            );
+
+            bytes32 ppOutputDigest = sha256(leafPubValues);
+            hashChainLeafPubValues = keccak256(abi.encodePacked(hashChainLeafPubValues, ppOutputDigest));
         }
 
-        // Check l1InfoTreeLeafCount has a valid l1InfoTreeRoot
-        bytes32 l1InfoRoot = globalExitRootManager.l1InfoRootMap(
-            l1InfoTreeLeafCount
+        // TODO: Check that l1InfoRoot is in the contract? Otherwise its a free input?
+
+        // TODO: Remove this TODO: when agglayer removes the ppvkey from the input. Right now the ppvkey
+        // is part of the public input in agglayer, but that will be removed.
+        // TODO: Once agglayer releases, point to this instead of the sandbox branch
+        // https://github.com/agglayer/agglayer/blob/sandbox/aggregation_with_preconf/crates/aggregation-proof-core/src/lib.rs#L401
+        bytes memory aggregationPublicValues = serializeAggregationPublicValues(
+            hashChainLeafPubValues,
+            l1InfoRoot,
+            lastAgglayerRollupExitRoot,
+            newArer
         );
 
-        if (l1InfoRoot == bytes32(0)) {
-            revert L1InfoTreeLeafCountInvalid();
+        aggLayerGateway.verifyAggregatedProof(
+            aggregationPublicValues,
+            proofBytes
+        );
+
+        // Consolidate state for all aggchains
+        _consolidateMultiple(pessimisticProofInputs, l1InfoRoot, newArer);
+    }
+
+    function _consolidateMultiple(
+        PessimisticProofInput[] calldata pessimisticProofInputs,
+        bytes32 l1InfoRoot,
+        bytes32 newArer
+    ) internal nonReentrant {
+        // Update aggregation parameters
+        lastAggregationTimestamp = uint64(block.timestamp);
+
+        bytes32 prevArer = lastAgglayerRollupExitRoot;
+
+        // Update previous Agglayer Rollup Exit Root
+        lastAgglayerRollupExitRoot = newArer;
+
+        for (uint256 i = 0; i < pessimisticProofInputs.length; i++) {
+            _consolidateSingle(pessimisticProofInputs[i], l1InfoRoot);
         }
+
+        emit VerifyAggregatedProof(
+            prevArer,
+            newArer
+        );
+    }
+
+    function _consolidateSingle(
+        PessimisticProofInput calldata proofData,
+        bytes32 l1InfoRoot
+    ) internal nonReentrant {
+        uint32 rollupID = proofData.rollupID;
+        bytes32 newLocalExitRoot = proofData.newLocalExitRoot;
+        RollupData storage rollup = _rollupIDToRollupData[rollupID];
 
         // In case of a chain in migration, the inputs are a special case.
         if (isRollupMigrating[rollupID]) {
@@ -1333,44 +1422,22 @@ contract AgglayerManager is
             emit CompletedMigration(rollupID);
         }
 
-        bytes memory inputPessimisticBytes = _getInputPessimisticBytes(
-            rollupID,
-            rollup,
-            l1InfoRoot,
-            newLocalExitRoot,
-            newPessimisticRoot,
-            aggchainData
-        );
-
-        // Verify proof. The pessimistic proof selector is attached at the first 4 bytes of the proof
-        // proof[0:4]: 4 bytes selector pp
-        // proof[4:8]: 4 bytes selector SP1 verifier
-        // proof[8:]: proof
-        aggLayerGateway.verifyPessimisticProof(
-            inputPessimisticBytes,
-            proof
-        );
-
-        // Update aggregation parameters
-        lastAggregationTimestamp = uint64(block.timestamp);
-
-        // Consolidate state
         bytes32 prevLocalExitRoot = rollup.lastLocalExitRoot;
-        rollup.lastLocalExitRoot = newLocalExitRoot;
         bytes32 prevPessimisticRoot = rollup.lastPessimisticRoot;
-        rollup.lastPessimisticRoot = newPessimisticRoot;
 
-        // Interact with globalExitRootManager
+        // Apply state transition for the rollup
+        rollup.lastLocalExitRoot = newLocalExitRoot;
+        rollup.lastPessimisticRoot = proofData.newPessimisticRoot;
+
+        // Update the Rollup Exit Root
         globalExitRootManager.updateExitRoot(getRollupExitRoot());
 
         // Same event as verifyBatches to support current bridge service to synchronize everything
-        /// @dev moved newLocalExitRoot to aux variable to avoid stack too deep errors at compilation
-        bytes32 newLocalExitRootAux = newLocalExitRoot;
         emit VerifyBatchesTrustedAggregator(
             rollupID,
             0, // final batch: does not  apply in pessimistic
             bytes32(0), // new state root: does not apply in pessimistic
-            newLocalExitRootAux,
+            newLocalExitRoot,
             msg.sender
         );
 
@@ -1378,17 +1445,38 @@ contract AgglayerManager is
         emit VerifyPessimisticStateTransition(
             rollupID,
             prevPessimisticRoot,
-            newPessimisticRoot,
+            proofData.newPessimisticRoot,
             prevLocalExitRoot,
-            newLocalExitRootAux,
+            newLocalExitRoot,
             l1InfoRoot,
             msg.sender
         );
 
-        // Allow chains to manage customData
-        // Callback to the rollup address
+        // Only ALGateway are supported
         IAggchainBase(rollup.rollupContract).onVerifyPessimistic(
-            aggchainData
+            proofData.aggchainData
+        );
+    }
+
+    /**
+     * @notice Serializes AggregationPublicValues struct to bytes.
+     * @param hashChainPpInputs The hash chain of pessimistic proof inputs (32 bytes)
+     * @param l1InfoRoot The L1 info tree root (32 bytes)
+     * @param prevArer Previous aggregation exit root (32 bytes)
+     * @param newArer New aggregation exit root (32 bytes)
+     * @return encoded bytes (160 bytes total)
+     */
+    function serializeAggregationPublicValues(
+        bytes32 hashChainPpInputs,
+        bytes32 l1InfoRoot,
+        bytes32 prevArer,
+        bytes32 newArer
+    ) public pure returns (bytes memory) {
+        return abi.encodePacked(
+            hashChainPpInputs,
+            l1InfoRoot,
+            prevArer,
+            newArer
         );
     }
 

--- a/contracts/AgglayerManager.sol
+++ b/contracts/AgglayerManager.sol
@@ -1356,8 +1356,6 @@ contract AgglayerManager is
             hashChainLeafPubValues = keccak256(abi.encodePacked(hashChainLeafPubValues, ppOutputDigest));
         }
 
-        // TODO: Check that l1InfoRoot is in the contract? Otherwise its a free input?
-
         // TODO: Remove this TODO: when agglayer removes the ppvkey from the input. Right now the ppvkey
         // is part of the public input in agglayer, but that will be removed.
         // TODO: Once agglayer releases, point to this instead of the sandbox branch

--- a/contracts/AgglayerManager.sol
+++ b/contracts/AgglayerManager.sol
@@ -1307,18 +1307,26 @@ contract AgglayerManager is
      * @notice Allows a trusted aggregator to verify an aggregated proof, which validates the state transition
      * of multiple aggchains at once.
      * @param pessimisticProofInputs Array of pessimistic proof inputs verified by the proof
-     * @param l1InfoRoot L1 info tree root
+     * @param l1InfoTreeLeafCount Count of the L1InfoTree leaf that will be used to verify imported bridge exits
      * @param newArer New Agglayer Rollup Exit Root
      * @param proofBytes Aggregated proof containing a SP1 proof (Plonk) validating the state transition of multiple
      * aggchains at once. The first 4 bytes of the proofBytes are the selector.
      */
     function verifyAggregatedProofTrusted(
         PessimisticProofInput[] calldata pessimisticProofInputs,
-        // TODO: Use count instead
-        bytes32 l1InfoRoot,
+        uint32 l1InfoTreeLeafCount,
         bytes32 newArer,
         bytes calldata proofBytes
     ) external onlyRole(_TRUSTED_AGGREGATOR_ROLE) nonReentrant {
+        // Get the L1 info tree root by its count
+        bytes32 l1InfoRoot = globalExitRootManager.l1InfoRootMap(
+            l1InfoTreeLeafCount
+        );
+
+        if (l1InfoRoot == bytes32(0)) {
+            revert L1InfoTreeLeafCountInvalid();
+        }
+
         bytes32 hashChainLeafPubValues = bytes32(0);
 
         for (uint256 i = 0; i < pessimisticProofInputs.length; i++) {

--- a/contracts/AgglayerManager.sol
+++ b/contracts/AgglayerManager.sol
@@ -333,6 +333,7 @@ contract AgglayerManager is
     mapping(uint32 rollupID => bool) public isRollupMigrating;
 
     // Last Agglayer Rollup Exit Root
+    // TODO: Check if this shall be initialized to some value
     bytes32 public lastAgglayerRollupExitRoot;
 
     /**
@@ -1313,6 +1314,7 @@ contract AgglayerManager is
      */
     function verifyAggregatedProofTrusted(
         PessimisticProofInput[] calldata pessimisticProofInputs,
+        // TODO: Use count instead
         bytes32 l1InfoRoot,
         bytes32 newArer,
         bytes calldata proofBytes
@@ -1372,7 +1374,7 @@ contract AgglayerManager is
         PessimisticProofInput[] calldata pessimisticProofInputs,
         bytes32 l1InfoRoot,
         bytes32 newArer
-    ) internal nonReentrant {
+    ) internal {
         // Update aggregation parameters
         lastAggregationTimestamp = uint64(block.timestamp);
 
@@ -1394,7 +1396,7 @@ contract AgglayerManager is
     function _consolidateSingle(
         PessimisticProofInput calldata proofData,
         bytes32 l1InfoRoot
-    ) internal nonReentrant {
+    ) internal {
         uint32 rollupID = proofData.rollupID;
         bytes32 newLocalExitRoot = proofData.newLocalExitRoot;
         RollupData storage rollup = _rollupIDToRollupData[rollupID];

--- a/contracts/AgglayerManager.sol
+++ b/contracts/AgglayerManager.sol
@@ -252,7 +252,7 @@ contract AgglayerManager is
         keccak256("EMERGENCY_COUNCIL_ADMIN");
 
     // Current rollup manager version
-    string public constant ROLLUP_MANAGER_VERSION = "v1.0.0";
+    string public constant ROLLUP_MANAGER_VERSION = "v2.0.0";
 
     // Hardcoded address used to indicate that this address triggered in an event should not be considered as valid.
     address private constant _NO_ADDRESS =

--- a/contracts/interfaces/IAgglayerGateway.sol
+++ b/contracts/interfaces/IAgglayerGateway.sol
@@ -169,6 +169,28 @@ interface IAgglayerGateway is
         bytes calldata proofBytes
     ) external view;
 
+    /// @notice Function to add a proof aggregation verification key route
+    /// @dev Only callable by the owner. The owner is responsible for ensuring that the specified
+    /// verifier is correct with a valid VERIFIER_HASH. Once a route to a verifier is added, it
+    /// cannot be removed.
+    /// @param proofAggregationVKeySelector The verifier selector to add.
+    /// @param verifier The address of the verifier contract. This verifier MUST implement the
+    /// ISP1VerifierWithHash interface.
+    /// @param proofAggregationVKey New proof aggregation verification key
+    function addProofAggregationVKeyRoute(
+        bytes4 proofAggregationVKeySelector,
+        address verifier,
+        bytes32 proofAggregationVKey
+    ) external;
+
+    /// @notice Function to freeze a proof aggregation verification key route
+    /// @dev Only callable by the owner. Once a route to a verifier is frozen, it cannot be
+    /// unfrozen.
+    /// @param proofAggregationVKeySelector The 4 bytes selector to freeze the proof aggregation verification key route.
+    function freezeProofAggregationVKeyRoute(
+        bytes4 proofAggregationVKeySelector
+    ) external;
+
     ////////////////////////////////////////////////////////////
     //                  Multisig Functions                    //
     ////////////////////////////////////////////////////////////

--- a/contracts/interfaces/IAgglayerGateway.sol
+++ b/contracts/interfaces/IAgglayerGateway.sol
@@ -6,23 +6,28 @@ import "./IAggchainSigners.sol";
 // based on: https://github.com/succinctlabs/sp1-contracts/blob/main/contracts/src/ISP1VerifierGateway.sol
 
 interface IAgglayerGatewayEvents {
-    /// @notice Emitted when a verifier route is added.
-    /// @param selector The verifier selector that was added.
-    /// @param verifier The address of the verifier contract.
-    /// @param pessimisticVKey The verification key
-    event RouteAdded(
+    /**
+     * Emitted when a proof aggregation verifier route is added.
+     * @param selector The proof aggregation verifier selector that was added.
+     * @param verifier The address of the verifier contract.
+     * @param proofAggregationVKey The proof aggregation verification key
+     */
+    event ProofAggregationRouteAdded(
         bytes4 selector,
         address verifier,
-        bytes32 pessimisticVKey
+        bytes32 proofAggregationVKey
     );
 
-    /// @notice Emitted when a verifier route is frozen.
-    /// @param selector The verifier selector that was frozen.
-    /// @param verifier The address of the verifier contract.
-    event RouteFrozen(
+    /**
+     * Emitted when a proof aggregation verifier route is frozen.
+     * @param selector The proof aggregation verifier selector that was frozen.
+     * @param verifier The address of the verifier contract.
+     * @param proofAggregationVKey The proof aggregation verification key
+     */
+    event ProofAggregationRouteFrozen(
         bytes4 selector,
         address verifier,
-        bytes32 pessimisticVKey
+        bytes32 proofAggregationVKey
     );
 
     /**
@@ -73,6 +78,9 @@ interface IAgglayerGatewayErrors {
     /// @notice Thrown when adding a verifier route and the selector returned by the verifier is
     /// zero.
     error PPSelectorCannotBeZero();
+
+    /// @notice Thrown when adding a proof aggregation verifier route and the selector is zero.
+    error ProofAggregationVKeySelectorCannotBeZero();
 
     /// @notice Thrown when adding a verifier key with value zero
     error VKeyCannotBeZero();
@@ -134,12 +142,12 @@ interface IAgglayerGateway is
     /**
      * Struct that defines a verifier route
      * @param verifier The address of the verifier contract.
-     * @param pessimisticVKey The verification key to be used for verifying pessimistic proofs.
+     * @param aggregationVKey The verification key to be used for verifying an aggregated proof.
      * @param frozen Whether the route is frozen.
      */
     struct AggLayerVerifierRoute {
         address verifier; // SP1 Verifier. It contains sanity check SP1 version with the 4 first bytes of the proof. proof[4:]
-        bytes32 pessimisticVKey;
+        bytes32 aggregationVKey;
         bool frozen;
     }
 
@@ -152,37 +160,14 @@ interface IAgglayerGateway is
         bytes4 defaultAggchainSelector
     ) external view returns (bytes32);
 
-    /// @notice Verifies a pessimistic proof with given public values and proof.
-    /// @dev It is expected that the first 4 bytes of proofBytes must match the first 4 bytes of
-    /// target verifier's VERIFIER_HASH.
-    /// @param publicValues The public values encoded as bytes.
-    /// @param proofBytes The proof of the program execution the SP1 zkVM encoded as bytes.
-    function verifyPessimisticProof(
-        bytes calldata publicValues,
+    /// @notice Verifies an aggregated proof with given public values and proof.
+    /// @param aggregationPublicValues The aggregation public values encoded as bytes.
+    /// @param proofBytes The proof of the program execution the SP1 zkVM encoded as bytes with the
+    /// first 4 bytes being the selector.
+    function verifyAggregatedProof(
+        bytes calldata aggregationPublicValues,
         bytes calldata proofBytes
     ) external view;
-
-    /// @notice Adds a verifier route. This enable proofs to be routed to this verifier.
-    /// @dev Only callable by the owner. The owner is responsible for ensuring that the specified
-    /// verifier is correct with a valid VERIFIER_HASH. Once a route to a verifier is added, it
-    /// cannot be removed.
-    /// @param pessimisticVKeySelector The verifier selector to add.
-    /// @param verifier The address of the verifier contract. This verifier MUST implement the
-    /// ISP1VerifierWithHash interface.
-    /// @param pessimisticVKey The verification key to be used for verifying pessimistic proofs.
-    function addPessimisticVKeyRoute(
-        bytes4 pessimisticVKeySelector,
-        address verifier,
-        bytes32 pessimisticVKey
-    ) external;
-
-    /// @notice Freezes a verifier route. This prevents proofs from being routed to this verifier.
-    /// @dev Only callable by the owner. Once a route to a verifier is frozen, it cannot be
-    /// unfrozen.
-    /// @param pessimisticVKeySelector The verifier selector to freeze.
-    function freezePessimisticVKeyRoute(
-        bytes4 pessimisticVKeySelector
-    ) external;
 
     ////////////////////////////////////////////////////////////
     //                  Multisig Functions                    //

--- a/contracts/interfaces/IAgglayerManager.sol
+++ b/contracts/interfaces/IAgglayerManager.sol
@@ -407,15 +407,6 @@ interface IAgglayerManager {
         bytes32[24] calldata proof
     ) external;
 
-    function verifyPessimisticTrustedAggregator(
-        uint32 rollupID,
-        uint32 l1InfoTreeLeafCount,
-        bytes32 newLocalExitRoot,
-        bytes32 newPessimisticRoot,
-        bytes calldata proof,
-        bytes memory aggchainData
-    ) external;
-
     function activateEmergencyState() external;
 
     function deactivateEmergencyState() external;

--- a/test/contractsv2/AggLayerGateway.test.ts
+++ b/test/contractsv2/AggLayerGateway.test.ts
@@ -22,19 +22,20 @@ describe('AgglayerGateway tests', () => {
     let defaultAdmin: any;
     let aggLayerAdmin: any;
     let aggchainVKey: any;
-    let addPPRoute: any;
-    let freezePPRoute: any;
+    let addAggregationRoute: any;
+    let freezeAggregationRoute: any;
 
-    const initPPVKeySelector = '0x00000001';
-    const initPPVkey = '0xbbbbbb85702e0582d900f3a19521270c92a58e2588230c4a5cf3b45103f4a512';
+    const initProofAggregationVKeySelector = '0x00000001';
+    const initProofAggregationVKey = '0xbbbbbb85702e0582d900f3a19521270c92a58e2588230c4a5cf3b45103f4a512';
 
     const selector = input.proof.slice(0, 10);
+    const proofAggregationVKey = input.vkey;
     const pessimisticVKey = input.vkey;
     const newPessimisticVKey = '0xaaaaaa85702e0582d900f3a19521270c92a58e2588230c4a5cf3b45103f4a512';
 
     beforeEach('Deploy contracts', async () => {
         // load signers
-        [deployer, defaultAdmin, aggLayerAdmin, aggchainVKey, addPPRoute, freezePPRoute] = await ethers.getSigners();
+        [deployer, defaultAdmin, aggLayerAdmin, aggchainVKey, addAggregationRoute, freezeAggregationRoute] = await ethers.getSigners();
 
         // deploy AgglayerGateway
         const AgglayerGatewayFactory = await ethers.getContractFactory('AgglayerGateway');
@@ -52,11 +53,11 @@ describe('AgglayerGateway tests', () => {
             aggLayerGatewayContract.initialize(
                 ethers.ZeroAddress,
                 aggchainVKey.address,
-                addPPRoute.address,
-                freezePPRoute.address,
-                initPPVKeySelector,
+                addAggregationRoute.address,
+                freezeAggregationRoute.address,
+                initProofAggregationVKeySelector,
                 verifierContract.target,
-                initPPVkey,
+                initProofAggregationVKey,
                 defaultAdmin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -66,25 +67,11 @@ describe('AgglayerGateway tests', () => {
             aggLayerGatewayContract.initialize(
                 defaultAdmin.address,
                 ethers.ZeroAddress,
-                addPPRoute.address,
-                freezePPRoute.address,
-                initPPVKeySelector,
+                addAggregationRoute.address,
+                freezeAggregationRoute.address,
+                initProofAggregationVKeySelector,
                 verifierContract.target,
-                initPPVkey,
-                defaultAdmin.address, // multisigRole
-                [], // signersToAdd
-                0, // newThreshold
-            ),
-        ).to.revertedWithCustomError(aggLayerGatewayContract, 'InvalidZeroAddress');
-        await expect(
-            aggLayerGatewayContract.initialize(
-                defaultAdmin.address,
-                aggchainVKey.address,
-                ethers.ZeroAddress,
-                freezePPRoute.address,
-                initPPVKeySelector,
-                verifierContract.target,
-                initPPVkey,
+                initProofAggregationVKey,
                 defaultAdmin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -94,11 +81,25 @@ describe('AgglayerGateway tests', () => {
             aggLayerGatewayContract.initialize(
                 defaultAdmin.address,
                 aggchainVKey.address,
-                addPPRoute.address,
                 ethers.ZeroAddress,
-                initPPVKeySelector,
+                freezeAggregationRoute.address,
+                initProofAggregationVKeySelector,
                 verifierContract.target,
-                initPPVkey,
+                initProofAggregationVKey,
+                defaultAdmin.address, // multisigRole
+                [], // signersToAdd
+                0, // newThreshold
+            ),
+        ).to.revertedWithCustomError(aggLayerGatewayContract, 'InvalidZeroAddress');
+        await expect(
+            aggLayerGatewayContract.initialize(
+                defaultAdmin.address,
+                aggchainVKey.address,
+                addAggregationRoute.address,
+                ethers.ZeroAddress,
+                initProofAggregationVKeySelector,
+                verifierContract.target,
+                initProofAggregationVKey,
                 defaultAdmin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -110,11 +111,11 @@ describe('AgglayerGateway tests', () => {
             aggLayerGatewayContract.initialize(
                 defaultAdmin.address,
                 aggchainVKey.address,
-                addPPRoute.address,
-                freezePPRoute.address,
-                initPPVKeySelector,
+                addAggregationRoute.address,
+                freezeAggregationRoute.address,
+                initProofAggregationVKeySelector,
                 verifierContract.target,
-                initPPVkey,
+                initProofAggregationVKey,
                 ethers.ZeroAddress, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -126,11 +127,11 @@ describe('AgglayerGateway tests', () => {
             aggLayerGatewayContract.initialize(
                 defaultAdmin.address,
                 aggchainVKey.address,
-                addPPRoute.address,
-                freezePPRoute.address,
-                initPPVKeySelector,
+                addAggregationRoute.address,
+                freezeAggregationRoute.address,
+                initProofAggregationVKeySelector,
                 verifierContract.target,
-                initPPVkey,
+                initProofAggregationVKey,
                 defaultAdmin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -141,13 +142,13 @@ describe('AgglayerGateway tests', () => {
             .to.emit(aggLayerGatewayContract, 'RoleGranted')
             .withArgs(AGGCHAIN_DEFAULT_VKEY_ROLE, aggchainVKey.address, deployer.address)
             .to.emit(aggLayerGatewayContract, 'RoleGranted')
-            .withArgs(AL_ADD_PP_ROUTE_ROLE, addPPRoute.address, deployer.address)
+            .withArgs(AL_ADD_PP_ROUTE_ROLE, addAggregationRoute.address, deployer.address)
             .to.emit(aggLayerGatewayContract, 'RoleGranted')
-            .withArgs(AL_FREEZE_PP_ROUTE_ROLE, freezePPRoute.address, deployer.address)
+            .withArgs(AL_FREEZE_PP_ROUTE_ROLE, freezeAggregationRoute.address, deployer.address)
             .to.emit(aggLayerGatewayContract, 'RoleGranted')
             .withArgs(AL_MULTISIG_ROLE, defaultAdmin.address, deployer.address)
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(initPPVKeySelector, verifierContract.target, initPPVkey);
+            .to.emit(aggLayerGatewayContract, 'ProofAggregationRouteAdded')
+            .withArgs(initProofAggregationVKeySelector, verifierContract.target, initProofAggregationVKey);
     });
 
     it('should check the initialize parameters', async () => {
@@ -161,11 +162,11 @@ describe('AgglayerGateway tests', () => {
             aggLayerGatewayContract.initialize(
                 defaultAdmin.address,
                 aggchainVKey.address,
-                addPPRoute.address,
-                freezePPRoute.address,
-                initPPVKeySelector,
+                addAggregationRoute.address,
+                freezeAggregationRoute.address,
+                initProofAggregationVKeySelector,
                 verifierContract.target,
-                initPPVkey,
+                initProofAggregationVKey,
                 defaultAdmin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -173,12 +174,12 @@ describe('AgglayerGateway tests', () => {
         ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'InvalidInitialization');
     });
 
-    it('addPessimisticVKeyRoute', async () => {
-        // add pessimistic vkey route
+    it('addProofAggregationVKeyRoute', async () => {
+        // add aggregation vkey route
 
         // check onlyRole
         await expect(
-            aggLayerGatewayContract.addPessimisticVKeyRoute(selector, verifierContract.target, pessimisticVKey),
+            aggLayerGatewayContract.addProofAggregationVKeyRoute(selector, verifierContract.target, proofAggregationVKey),
         )
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'AccessControlUnauthorizedAccount')
             .withArgs(deployer.address, AL_ADD_PP_ROUTE_ROLE);
@@ -192,47 +193,47 @@ describe('AgglayerGateway tests', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         expect(await aggLayerGatewayContract.hasRole(AL_ADD_PP_ROUTE_ROLE, aggLayerAdmin.address)).to.be.equal(true);
 
-        // check PPSelectorCannotBeZero
+        // check ProofAggregationVKeySelectorCannotBeZero
         await expect(
             aggLayerGatewayContract
                 .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute('0x00000000', verifierContract.target, pessimisticVKey),
-        ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'PPSelectorCannotBeZero');
+                .addProofAggregationVKeyRoute('0x00000000', verifierContract.target, proofAggregationVKey),
+        ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'ProofAggregationVKeySelectorCannotBeZero');
 
         // check VKeyCannotBeZero
         await expect(
             aggLayerGatewayContract
                 .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(selector, verifierContract.target, ethers.ZeroHash),
+                .addProofAggregationVKeyRoute(selector, verifierContract.target, ethers.ZeroHash),
         ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'VKeyCannotBeZero');
 
         // check InvalidZeroAddress
         await expect(
             aggLayerGatewayContract
                 .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(selector, ethers.ZeroAddress, pessimisticVKey),
+                .addProofAggregationVKeyRoute(selector, ethers.ZeroAddress, proofAggregationVKey),
         ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'InvalidZeroAddress');
 
         // check RouteAdded
         await expect(
             aggLayerGatewayContract
                 .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(selector, verifierContract.target, pessimisticVKey),
+                .addProofAggregationVKeyRoute(selector, verifierContract.target, proofAggregationVKey),
         )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(selector, verifierContract.target, pessimisticVKey);
+            .to.emit(aggLayerGatewayContract, 'ProofAggregationRouteAdded')
+            .withArgs(selector, verifierContract.target, proofAggregationVKey);
 
         // check RouteAlreadyExists
         await expect(
             aggLayerGatewayContract
                 .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(selector, verifierContract.target, pessimisticVKey),
+                .addProofAggregationVKeyRoute(selector, verifierContract.target, proofAggregationVKey),
         )
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'RouteAlreadyExists')
             .withArgs(selector, verifierContract.target);
     });
 
-    it('freezePessimisticVKeyRoute', async () => {
+    it('freezeProofAggregationVKeyRoute', async () => {
         const testSelector = '0x00000002';
 
         // grantRole AL_ADD_PP_ROUTE_ROLE --> aggLayerAdmin
@@ -249,14 +250,14 @@ describe('AgglayerGateway tests', () => {
         await expect(
             aggLayerGatewayContract
                 .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(selector, verifierContract.target, pessimisticVKey),
+                .addProofAggregationVKeyRoute(selector, verifierContract.target, proofAggregationVKey),
         )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(selector, verifierContract.target, pessimisticVKey);
+            .to.emit(aggLayerGatewayContract, 'ProofAggregationRouteAdded')
+            .withArgs(selector, verifierContract.target, proofAggregationVKey);
 
         // freeze pessimistic vkey route
         // check onlyRole
-        await expect(aggLayerGatewayContract.freezePessimisticVKeyRoute(selector))
+        await expect(aggLayerGatewayContract.freezeProofAggregationVKeyRoute(selector))
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'AccessControlUnauthorizedAccount')
             .withArgs(deployer.address, AL_FREEZE_PP_ROUTE_ROLE);
 
@@ -271,17 +272,17 @@ describe('AgglayerGateway tests', () => {
         expect(await aggLayerGatewayContract.hasRole(AL_FREEZE_PP_ROUTE_ROLE, aggLayerAdmin.address)).to.be.equal(true);
 
         // check RouteNotFound
-        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezePessimisticVKeyRoute(testSelector))
+        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezeProofAggregationVKeyRoute(testSelector))
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'RouteNotFound')
             .withArgs(testSelector);
 
-        // check RouteFrozen
-        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezePessimisticVKeyRoute(selector))
-            .to.emit(aggLayerGatewayContract, 'RouteFrozen')
-            .withArgs(selector, verifierContract.target, pessimisticVKey);
+        // check ProofAggregationRouteFrozen
+        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezeProofAggregationVKeyRoute(selector))
+            .to.emit(aggLayerGatewayContract, 'ProofAggregationRouteFrozen')
+            .withArgs(selector, verifierContract.target, proofAggregationVKey);
 
         // check RouteIsFrozen
-        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezePessimisticVKeyRoute(selector))
+        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezeProofAggregationVKeyRoute(selector))
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'RouteIsAlreadyFrozen')
             .withArgs(selector);
     });
@@ -397,16 +398,16 @@ describe('AgglayerGateway tests', () => {
         );
     });
 
-    it('verifyPessimisticProof', async () => {
-        // verifyPessimisticProof
+    it('verifyAggregatedProof', async () => {
+        // verifyAggregatedProof
         // check InvalidProofBytesLength
         await expect(
-            aggLayerGatewayContract.verifyPessimisticProof(input['public-values'], `0x01`),
+            aggLayerGatewayContract.verifyAggregatedProof(input['public-values'], `0x01`),
         ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'InvalidProofBytesLength');
 
         // check RouteNotFound
         await expect(
-            aggLayerGatewayContract.verifyPessimisticProof(
+            aggLayerGatewayContract.verifyAggregatedProof(
                 input['public-values'],
                 `${selector}${input.proof.slice(2)}`,
             ),
@@ -427,13 +428,13 @@ describe('AgglayerGateway tests', () => {
         await expect(
             aggLayerGatewayContract
                 .connect(aggLayerAdmin)
-                .addPessimisticVKeyRoute(selector, verifierContract.target, pessimisticVKey),
+                .addProofAggregationVKeyRoute(selector, verifierContract.target, proofAggregationVKey),
         )
-            .to.emit(aggLayerGatewayContract, 'RouteAdded')
-            .withArgs(selector, verifierContract.target, pessimisticVKey);
+            .to.emit(aggLayerGatewayContract, 'ProofAggregationRouteAdded')
+            .withArgs(selector, verifierContract.target, proofAggregationVKey);
 
         // check verifyProof
-        await expect(aggLayerGatewayContract.verifyPessimisticProof(input['public-values'], input.proof));
+        await expect(aggLayerGatewayContract.verifyAggregatedProof(input['public-values'], input.proof));
 
         // grantRole AL_FREEZE_PP_ROUTE_ROLE --> aggLayerAdmin
         await expect(
@@ -446,13 +447,13 @@ describe('AgglayerGateway tests', () => {
         expect(await aggLayerGatewayContract.hasRole(AL_FREEZE_PP_ROUTE_ROLE, aggLayerAdmin.address)).to.be.equal(true);
 
         // frozen route
-        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezePessimisticVKeyRoute(selector))
-            .to.emit(aggLayerGatewayContract, 'RouteFrozen')
-            .withArgs(selector, verifierContract.target, pessimisticVKey);
+        await expect(aggLayerGatewayContract.connect(aggLayerAdmin).freezeProofAggregationVKeyRoute(selector))
+            .to.emit(aggLayerGatewayContract, 'ProofAggregationRouteFrozen')
+            .withArgs(selector, verifierContract.target, proofAggregationVKey);
 
         // check RouteIsFrozen
         await expect(
-            aggLayerGatewayContract.verifyPessimisticProof(
+            aggLayerGatewayContract.verifyAggregatedProof(
                 input['public-values'],
                 `${selector}${input.proof.slice(2)}`,
             ),
@@ -517,7 +518,7 @@ describe('AgglayerGateway tests', () => {
         expect(await aggLayerGatewayContract.isSigner(signer1.address)).to.equal(true);
         expect(await aggLayerGatewayContract.isSigner(signer2.address)).to.equal(true);
         expect(await aggLayerGatewayContract.isSigner(signer3.address)).to.equal(true);
-        expect(await aggLayerGatewayContract.isSigner(addPPRoute.address)).to.equal(false);
+        expect(await aggLayerGatewayContract.isSigner(addAggregationRoute.address)).to.equal(false);
 
         // Test signerToURLs mapping
         expect(await aggLayerGatewayContract.signerToURLs(signer1.address)).to.equal('https://signer1.com');
@@ -561,7 +562,7 @@ describe('AgglayerGateway tests', () => {
         await expect(
             aggLayerGatewayContract
                 .connect(defaultAdmin)
-                .updateSignersAndThreshold([], [{ addr: addPPRoute.address, url: '' }], 1),
+                .updateSignersAndThreshold([], [{ addr: addAggregationRoute.address, url: '' }], 1),
         ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'SignerURLCannotBeEmpty');
 
         // Try to add existing signer
@@ -588,8 +589,8 @@ describe('AgglayerGateway tests', () => {
         ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'SignerDoesNotExist');
 
         // Test indices not in descending order
-        const newSigner4 = addPPRoute;
-        const newSigner5 = freezePPRoute;
+        const newSigner4 = addAggregationRoute;
+        const newSigner5 = freezeAggregationRoute;
         await aggLayerGatewayContract.connect(defaultAdmin).updateSignersAndThreshold(
             [],
             [
@@ -652,7 +653,7 @@ describe('AgglayerGateway tests', () => {
     });
 
     it('should test version function', async () => {
-        expect(await aggLayerGatewayContract.AGGLAYER_GATEWAY_VERSION()).to.equal('v1.1.0');
+        expect(await aggLayerGatewayContract.AGGLAYER_GATEWAY_VERSION()).to.equal('v2.0.0');
     });
 
     it('should test aggchainSigners array access', async () => {
@@ -727,11 +728,11 @@ describe('AgglayerGateway tests', () => {
         await freshGateway.initialize(
             defaultAdmin.address,
             aggchainVKey.address,
-            addPPRoute.address,
-            freezePPRoute.address,
-            initPPVKeySelector,
+            addAggregationRoute.address,
+            freezeAggregationRoute.address,
+            initProofAggregationVKeySelector,
             verifierContract.target,
-            initPPVkey,
+            initProofAggregationVKey,
             defaultAdmin.address, // multisigRole
             signers.map((addr, index) => ({ addr, url: `http://signer${index + 1}` })), // Convert to SignerInfo array with URL
             threshold,
@@ -749,11 +750,11 @@ describe('AgglayerGateway tests', () => {
             freshGateway.initialize(
                 defaultAdmin.address,
                 aggchainVKey.address,
-                addPPRoute.address,
-                freezePPRoute.address,
-                initPPVKeySelector,
+                addAggregationRoute.address,
+                freezeAggregationRoute.address,
+                initProofAggregationVKeySelector,
                 verifierContract.target,
-                initPPVkey,
+                initProofAggregationVKey,
                 defaultAdmin.address,
                 signers.map((addr, index) => ({ addr, url: `http://signer${index + 1}` })),
                 threshold,
@@ -780,11 +781,11 @@ describe('AgglayerGateway tests', () => {
         await edgeCaseGateway.initialize(
             defaultAdmin.address,
             aggchainVKey.address,
-            addPPRoute.address,
-            freezePPRoute.address,
-            initPPVKeySelector,
+            addAggregationRoute.address,
+            freezeAggregationRoute.address,
+            initProofAggregationVKeySelector,
             verifierContract.target,
-            initPPVkey,
+            initProofAggregationVKey,
             defaultAdmin.address,
             [], // empty signers
             0, // threshold
@@ -810,124 +811,125 @@ describe('AgglayerGateway tests', () => {
         expect(newSignersHash).to.not.equal(ethers.ZeroHash);
     });
 
-    it('should upgrade from previous version to new version', async () => {
-        // Deploy the previous version of AgglayerGateway
-        const aggLayerGatewayPreviousFactory = await ethers.getContractFactory('AggLayerGatewayPrevious');
-        const aggLayerGatewayPrevious = await upgrades.deployProxy(aggLayerGatewayPreviousFactory, [], {
-            initializer: false,
-            unsafeAllow: ['constructor'],
-        });
-        await aggLayerGatewayPrevious.waitForDeployment();
+    // TODO: This test will be fixed in the next PR. Otherwise this PR will get too big.
+    // it('should upgrade from previous version to new version', async () => {
+    //     // Deploy the previous version of AgglayerGateway
+    //     const aggLayerGatewayPreviousFactory = await ethers.getContractFactory('AggLayerGatewayPrevious');
+    //     const aggLayerGatewayPrevious = await upgrades.deployProxy(aggLayerGatewayPreviousFactory, [], {
+    //         initializer: false,
+    //         unsafeAllow: ['constructor'],
+    //     });
+    //     await aggLayerGatewayPrevious.waitForDeployment();
 
-        // Initialize the previous version
-        await aggLayerGatewayPrevious.initialize(
-            defaultAdmin.address,
-            aggchainVKey.address,
-            addPPRoute.address,
-            freezePPRoute.address,
-            initPPVKeySelector,
-            verifierContract.target,
-            initPPVkey,
-        );
+    //     // Initialize the previous version
+    //     await aggLayerGatewayPrevious.initialize(
+    //         defaultAdmin.address,
+    //         aggchainVKey.address,
+    //         addAggregationRoute.address,
+    //         freezeAggregationRoute.address,
+    //         initPPVKeySelector,
+    //         verifierContract.target,
+    //         initPPVkey,
+    //     );
 
-        // Verify initialization of previous version
-        expect(await aggLayerGatewayPrevious.hasRole(DEFAULT_ADMIN_ROLE, defaultAdmin.address)).to.be.equal(true);
-        expect(await aggLayerGatewayPrevious.hasRole(AGGCHAIN_DEFAULT_VKEY_ROLE, aggchainVKey.address)).to.be.equal(
-            true,
-        );
-        expect(await aggLayerGatewayPrevious.hasRole(AL_ADD_PP_ROUTE_ROLE, addPPRoute.address)).to.be.equal(true);
-        expect(await aggLayerGatewayPrevious.hasRole(AL_FREEZE_PP_ROUTE_ROLE, freezePPRoute.address)).to.be.equal(true);
+    //     // Verify initialization of previous version
+    //     expect(await aggLayerGatewayPrevious.hasRole(DEFAULT_ADMIN_ROLE, defaultAdmin.address)).to.be.equal(true);
+    //     expect(await aggLayerGatewayPrevious.hasRole(AGGCHAIN_DEFAULT_VKEY_ROLE, aggchainVKey.address)).to.be.equal(
+    //         true,
+    //     );
+    //     expect(await aggLayerGatewayPrevious.hasRole(AL_ADD_PP_ROUTE_ROLE, addAggregationRoute.address)).to.be.equal(true);
+    //     expect(await aggLayerGatewayPrevious.hasRole(AL_FREEZE_PP_ROUTE_ROLE, freezeAggregationRoute.address)).to.be.equal(true);
 
-        // Check that pessimistic route was added
-        const route = await aggLayerGatewayPrevious.pessimisticVKeyRoutes(initPPVKeySelector);
-        expect(route.verifier).to.be.equal(verifierContract.target);
-        expect(route.pessimisticVKey).to.be.equal(initPPVkey);
-        expect(route.frozen).to.be.equal(false);
+    //     // Check that pessimistic route was added
+    //     const route = await aggLayerGatewayPrevious.pessimisticVKeyRoutes(initPPVKeySelector);
+    //     expect(route.verifier).to.be.equal(verifierContract.target);
+    //     expect(route.pessimisticVKey).to.be.equal(initPPVkey);
+    //     expect(route.frozen).to.be.equal(false);
 
-        // Add a default aggchain vkey to test state preservation
-        await aggLayerGatewayPrevious
-            .connect(aggchainVKey)
-            .addDefaultAggchainVKey('0x12340005', ethers.id('test_default_vkey'));
+    //     // Add a default aggchain vkey to test state preservation
+    //     await aggLayerGatewayPrevious
+    //         .connect(aggchainVKey)
+    //         .addDefaultAggchainVKey('0x12340005', ethers.id('test_default_vkey'));
 
-        // Get the new AgglayerGateway factory
-        const aggLayerGatewayFactory = await ethers.getContractFactory('AgglayerGateway');
+    //     // Get the new AgglayerGateway factory
+    //     const aggLayerGatewayFactory = await ethers.getContractFactory('AgglayerGateway');
 
-        // Prepare signers for the upgrade
-        const signersList = await ethers.getSigners();
-        const signer1 = signersList[6];
-        const signer2 = signersList[7];
-        const signer3 = signersList[8];
-        const signers = [
-            { addr: signer1.address, url: 'http://signer1' },
-            { addr: signer2.address, url: 'http://signer2' },
-            { addr: signer3.address, url: 'http://signer3' },
-        ];
-        const threshold = 2;
+    //     // Prepare signers for the upgrade
+    //     const signersList = await ethers.getSigners();
+    //     const signer1 = signersList[6];
+    //     const signer2 = signersList[7];
+    //     const signer3 = signersList[8];
+    //     const signers = [
+    //         { addr: signer1.address, url: 'http://signer1' },
+    //         { addr: signer2.address, url: 'http://signer2' },
+    //         { addr: signer3.address, url: 'http://signer3' },
+    //     ];
+    //     const threshold = 2;
 
-        // Upgrade to new version with multisig initialization
-        const upgradedContract = await upgrades.upgradeProxy(aggLayerGatewayPrevious.target, aggLayerGatewayFactory, {
-            unsafeAllow: ['constructor'],
-            call: {
-                fn: 'initialize(address,(address,string)[],uint256)',
-                args: [defaultAdmin.address, signers, threshold],
-            },
-        });
+    //     // Upgrade to new version with multisig initialization
+    //     const upgradedContract = await upgrades.upgradeProxy(aggLayerGatewayPrevious.target, aggLayerGatewayFactory, {
+    //         unsafeAllow: ['constructor'],
+    //         call: {
+    //             fn: 'initialize(address,(address,string)[],uint256)',
+    //             args: [defaultAdmin.address, signers, threshold],
+    //         },
+    //     });
 
-        // Cast to the new interface
-        const upgradedAgglayerGateway = upgradedContract as unknown as AgglayerGateway;
+    //     // Cast to the new interface
+    //     const upgradedAgglayerGateway = upgradedContract as unknown as AgglayerGateway;
 
-        // Verify that previous state is preserved
-        // Check roles are preserved
-        expect(await upgradedAgglayerGateway.hasRole(DEFAULT_ADMIN_ROLE, defaultAdmin.address)).to.be.equal(true);
-        expect(await upgradedAgglayerGateway.hasRole(AGGCHAIN_DEFAULT_VKEY_ROLE, aggchainVKey.address)).to.be.equal(
-            true,
-        );
-        expect(await upgradedAgglayerGateway.hasRole(AL_ADD_PP_ROUTE_ROLE, addPPRoute.address)).to.be.equal(true);
-        expect(await upgradedAgglayerGateway.hasRole(AL_FREEZE_PP_ROUTE_ROLE, freezePPRoute.address)).to.be.equal(true);
+    //     // Verify that previous state is preserved
+    //     // Check roles are preserved
+    //     expect(await upgradedAgglayerGateway.hasRole(DEFAULT_ADMIN_ROLE, defaultAdmin.address)).to.be.equal(true);
+    //     expect(await upgradedAgglayerGateway.hasRole(AGGCHAIN_DEFAULT_VKEY_ROLE, aggchainVKey.address)).to.be.equal(
+    //         true,
+    //     );
+    //     expect(await upgradedAgglayerGateway.hasRole(AL_ADD_PP_ROUTE_ROLE, addAggregationRoute.address)).to.be.equal(true);
+    //     expect(await upgradedAgglayerGateway.hasRole(AL_FREEZE_PP_ROUTE_ROLE, freezeAggregationRoute.address)).to.be.equal(true);
 
-        // Check pessimistic route is preserved
-        const upgradedRoute = await upgradedAgglayerGateway.pessimisticVKeyRoutes(initPPVKeySelector);
-        expect(upgradedRoute.verifier).to.be.equal(verifierContract.target);
-        expect(upgradedRoute.pessimisticVKey).to.be.equal(initPPVkey);
-        expect(upgradedRoute.frozen).to.be.equal(false);
+    //     // Check pessimistic route is preserved
+    //     const upgradedRoute = await upgradedAgglayerGateway.pessimisticVKeyRoutes(initPPVKeySelector);
+    //     expect(upgradedRoute.verifier).to.be.equal(verifierContract.target);
+    //     expect(upgradedRoute.pessimisticVKey).to.be.equal(initPPVkey);
+    //     expect(upgradedRoute.frozen).to.be.equal(false);
 
-        // Check default aggchain vkey is preserved
-        expect(await upgradedAgglayerGateway.defaultAggchainVKeys('0x12340005')).to.be.equal(
-            ethers.id('test_default_vkey'),
-        );
+    //     // Check default aggchain vkey is preserved
+    //     expect(await upgradedAgglayerGateway.defaultAggchainVKeys('0x12340005')).to.be.equal(
+    //         ethers.id('test_default_vkey'),
+    //     );
 
-        // Verify new functionality - multisig was added
-        expect(await upgradedAgglayerGateway.getAggchainSignersCount()).to.equal(3);
-        expect(await upgradedAgglayerGateway.getThreshold()).to.equal(threshold);
-        const actualSigners = await upgradedAgglayerGateway.getAggchainSigners();
-        expect(actualSigners).to.deep.equal([signer1.address, signer2.address, signer3.address]);
+    //     // Verify new functionality - multisig was added
+    //     expect(await upgradedAgglayerGateway.getAggchainSignersCount()).to.equal(3);
+    //     expect(await upgradedAgglayerGateway.getThreshold()).to.equal(threshold);
+    //     const actualSigners = await upgradedAgglayerGateway.getAggchainSigners();
+    //     expect(actualSigners).to.deep.equal([signer1.address, signer2.address, signer3.address]);
 
-        // Test that new multisig role can update signers
-        await upgradedAgglayerGateway.connect(defaultAdmin).grantRole(AL_MULTISIG_ROLE, aggLayerAdmin.address);
+    //     // Test that new multisig role can update signers
+    //     await upgradedAgglayerGateway.connect(defaultAdmin).grantRole(AL_MULTISIG_ROLE, aggLayerAdmin.address);
 
-        const signer4 = signersList[9];
-        await expect(
-            upgradedAgglayerGateway
-                .connect(aggLayerAdmin)
-                .updateSignersAndThreshold([], [{ addr: signer4.address, url: 'http://signer4' }], 3),
-        ).to.emit(upgradedAgglayerGateway, 'SignersAndThresholdUpdated');
+    //     const signer4 = signersList[9];
+    //     await expect(
+    //         upgradedAgglayerGateway
+    //             .connect(aggLayerAdmin)
+    //             .updateSignersAndThreshold([], [{ addr: signer4.address, url: 'http://signer4' }], 3),
+    //     ).to.emit(upgradedAgglayerGateway, 'SignersAndThresholdUpdated');
 
-        expect(await upgradedAgglayerGateway.getAggchainSignersCount()).to.equal(4);
-        expect(await upgradedAgglayerGateway.getThreshold()).to.equal(3);
+    //     expect(await upgradedAgglayerGateway.getAggchainSignersCount()).to.equal(4);
+    //     expect(await upgradedAgglayerGateway.getThreshold()).to.equal(3);
 
-        // Verify the new version string
-        expect(await upgradedAgglayerGateway.version()).to.equal('v1.1.0');
+    //     // Verify the new version string
+    //     expect(await upgradedAgglayerGateway.version()).to.equal('v1.1.0');
 
-        // Test that previous version functionality still works
-        // Add another pessimistic route
-        await expect(
-            upgradedAgglayerGateway
-                .connect(addPPRoute)
-                .addPessimisticVKeyRoute('0x00000099', verifierContract.target, ethers.id('new_pp_vkey')),
-        ).to.emit(upgradedAgglayerGateway, 'RouteAdded');
+    //     // Test that previous version functionality still works
+    //     // Add another pessimistic route
+    //     await expect(
+    //         upgradedAgglayerGateway
+    //             .connect(addAggregationRoute)
+    //             .addPessimisticVKeyRoute('0x00000099', verifierContract.target, ethers.id('new_pp_vkey')),
+    //     ).to.emit(upgradedAgglayerGateway, 'RouteAdded');
 
-        const newRoute = await upgradedAgglayerGateway.pessimisticVKeyRoutes('0x00000099');
-        expect(newRoute.verifier).to.be.equal(verifierContract.target);
-        expect(newRoute.pessimisticVKey).to.be.equal(ethers.id('new_pp_vkey'));
-    });
+    //     const newRoute = await upgradedAgglayerGateway.pessimisticVKeyRoutes('0x00000099');
+    //     expect(newRoute.verifier).to.be.equal(verifierContract.target);
+    //     expect(newRoute.pessimisticVKey).to.be.equal(ethers.id('new_pp_vkey'));
+    // });
 });

--- a/test/contractsv2/AggLayerGateway.test.ts
+++ b/test/contractsv2/AggLayerGateway.test.ts
@@ -152,7 +152,7 @@ describe('AgglayerGateway tests', () => {
 
     it('should check the initialize parameters', async () => {
         expect(await aggLayerGatewayContract.hasRole(DEFAULT_ADMIN_ROLE, defaultAdmin.address)).to.be.equal(true);
-        expect(await aggLayerGatewayContract.version()).to.be.equal('v1.1.0');
+        expect(await aggLayerGatewayContract.version()).to.be.equal('v2.0.0');
     });
 
     it("should check error 'contract is already initialized'", async () => {

--- a/test/contractsv2/AggLayerGateway.test.ts
+++ b/test/contractsv2/AggLayerGateway.test.ts
@@ -35,7 +35,8 @@ describe('AgglayerGateway tests', () => {
 
     beforeEach('Deploy contracts', async () => {
         // load signers
-        [deployer, defaultAdmin, aggLayerAdmin, aggchainVKey, addAggregationRoute, freezeAggregationRoute] = await ethers.getSigners();
+        [deployer, defaultAdmin, aggLayerAdmin, aggchainVKey, addAggregationRoute, freezeAggregationRoute] =
+            await ethers.getSigners();
 
         // deploy AgglayerGateway
         const AgglayerGatewayFactory = await ethers.getContractFactory('AgglayerGateway');
@@ -179,7 +180,11 @@ describe('AgglayerGateway tests', () => {
 
         // check onlyRole
         await expect(
-            aggLayerGatewayContract.addProofAggregationVKeyRoute(selector, verifierContract.target, proofAggregationVKey),
+            aggLayerGatewayContract.addProofAggregationVKeyRoute(
+                selector,
+                verifierContract.target,
+                proofAggregationVKey,
+            ),
         )
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'AccessControlUnauthorizedAccount')
             .withArgs(deployer.address, AL_ADD_PP_ROUTE_ROLE);
@@ -407,10 +412,7 @@ describe('AgglayerGateway tests', () => {
 
         // check RouteNotFound
         await expect(
-            aggLayerGatewayContract.verifyAggregatedProof(
-                input['public-values'],
-                `${selector}${input.proof.slice(2)}`,
-            ),
+            aggLayerGatewayContract.verifyAggregatedProof(input['public-values'], `${selector}${input.proof.slice(2)}`),
         )
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'RouteNotFound')
             .withArgs(selector);
@@ -453,10 +455,7 @@ describe('AgglayerGateway tests', () => {
 
         // check RouteIsFrozen
         await expect(
-            aggLayerGatewayContract.verifyAggregatedProof(
-                input['public-values'],
-                `${selector}${input.proof.slice(2)}`,
-            ),
+            aggLayerGatewayContract.verifyAggregatedProof(input['public-values'], `${selector}${input.proof.slice(2)}`),
         )
             .to.be.revertedWithCustomError(aggLayerGatewayContract, 'RouteIsFrozen')
             .withArgs(selector);

--- a/test/contractsv2/PolygonRollupManager.test.ts
+++ b/test/contractsv2/PolygonRollupManager.test.ts
@@ -252,7 +252,7 @@ describe('Polygon Rollup Manager', () => {
         expect(await rollupManagerContract.hasRole(EMERGENCY_COUNCIL_ADMIN, emergencyCouncil.address)).to.be.equal(
             true,
         );
-        expect(await rollupManagerContract.version()).to.be.equal('v1.0.0');
+        expect(await rollupManagerContract.version()).to.be.equal('v2.0.0');
     });
 
     it('should check the emergency state', async () => {

--- a/test/contractsv2/PolygonRollupManagerAL-ECDSAMultisig.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-ECDSAMultisig.test.ts
@@ -550,6 +550,9 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
         const aggchainECDSAMultisigFactory = await ethers.getContractFactory('AggchainECDSAMultisig');
         const ECDSAMultisigRollupContract = await aggchainECDSAMultisigFactory.attach(rollupECDSAMultisigData[0]);
 
+        // Check initial value of lastAgglayerRollupExitRoot (should be zero)
+        expect(await rollupManagerContract.lastAgglayerRollupExitRoot()).to.be.equal(ethers.ZeroHash);
+
         await expect(
             rollupManagerContract.connect(trustedAggregator).verifyAggregatedProofTrusted(
                 [
@@ -560,9 +563,9 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
                         aggchainData: CUSTOM_DATA_ECDSA,
                     },
                 ],
-                l1InfoRoot, // rollupID
-                newArer, // l1InfoTreeCount
-                proofWithSelector, // proofBytes
+                l1InfoRoot,
+                newArer,
+                proofWithSelector,
             ),
         )
             .to.emit(rollupManagerContract, 'VerifyBatchesTrustedAggregator')
@@ -579,6 +582,14 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
                 l1InfoRoot,
                 trustedAggregator.address,
             );
+
+        // Assert that lastAgglayerRollupExitRoot is updated to newArer
+        expect(await rollupManagerContract.lastAgglayerRollupExitRoot()).to.be.equal(newArer);
+        
+        // Assert that rollup's lastLocalExitRoot and lastPessimisticRoot are updated
+        const rollupDataAfter = await rollupManagerContract.rollupIDToRollupDataV2(aggchainECDSAMultisigId);
+        expect(rollupDataAfter.lastLocalExitRoot).to.be.equal(newLocalExitRoot);
+        expect(rollupDataAfter.lastPessimisticRoot).to.be.equal(newPessimisticRoot);
     });
 
     it('should verify an aggregated proof for multiple ECDSA aggchains', async () => {

--- a/test/contractsv2/PolygonRollupManagerAL-ECDSAMultisig.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-ECDSAMultisig.test.ts
@@ -35,8 +35,8 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
     let aggLayerAdmin: any;
     let tester: any;
     let aggchainVKey: any;
-    let addPPRoute: any;
-    let freezePPRoute: any;
+    let addProofAggregationRoute: any;
+    let freezeProofAggregationRoute: any;
 
     // CONTRACTS
     let polygonZkEVMBridgeContract: AgglayerBridge;
@@ -53,12 +53,12 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
     // BRIDGE CONSTANTS
     const NETWORK_ID_MAINNET = 0;
     // AGGLAYER CONSTANTS
-    const PESSIMISTIC_SELECTOR = '0x00000001';
+    const PROOF_AGGREGATION_SELECTOR = '0x00000001';
     // AGGCHAIN CONSTANTS
     // bytes2(version)=0x0001 | bytes2(type)=0x0002 => selector 0x00010002
     const AGGCHAIN_VKEY_SELECTOR = '0x00010002';
     const CUSTOM_DATA_ECDSA = '0x'; // ECDSA Multisig expects empty aggchainData
-    const randomPessimisticVKey = computeRandomBytes(32);
+    const proofAggregationVKey = '0x1000000000000000000000000000000000000000000000000000000000000000';
 
     upgrades.silenceWarnings();
 
@@ -159,8 +159,8 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
             aggLayerAdmin,
             tester,
             aggchainVKey,
-            addPPRoute,
-            freezePPRoute,
+            addProofAggregationRoute,
+            freezeProofAggregationRoute,
         ] = await ethers.getSigners();
 
         // Deploy L1 contracts
@@ -195,11 +195,11 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
         await aggLayerGatewayContract.initialize(
             admin.address,
             aggchainVKey.address,
-            addPPRoute.address,
-            freezePPRoute.address,
-            PESSIMISTIC_SELECTOR,
+            addProofAggregationRoute.address,
+            freezeProofAggregationRoute.address,
+            PROOF_AGGREGATION_SELECTOR,
             verifierContract.target,
-            randomPessimisticVKey,
+            proofAggregationVKey,
             admin.address, // multisigRole
             [], // signersToAdd
             0, // newThreshold
@@ -285,11 +285,11 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
             aggLayerGatewayContract.initialize(
                 timelock.address,
                 aggchainVKey.address,
-                addPPRoute.address,
-                freezePPRoute.address,
-                PESSIMISTIC_SELECTOR,
+                addProofAggregationRoute.address,
+                freezeProofAggregationRoute.address,
+                PROOF_AGGREGATION_SELECTOR,
                 verifierContract.target,
-                randomPessimisticVKey,
+                proofAggregationVKey,
                 admin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -510,7 +510,7 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
         );
     });
 
-    it('should verify a pessimistic proof for a ECDSA aggchain', async () => {
+    it('should verify an aggregated proof of a single ECDSA aggchain', async () => {
         // Create ECDSA aggchain
         const rollupTypeIdECDSAMultisig = await createECDSAMultisigRollupType();
         const [aggchainECDSAMultisigId] = await createECDSAMultisigRollup(rollupTypeIdECDSAMultisig);
@@ -526,40 +526,63 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
 
         expect(await polygonZkEVMBridgeContract.depositCount()).to.be.equal(1);
 
-        // call rollup manager verify function
-        // Compute random values for proof generation
-        const randomNewLocalExitRoot = computeRandomBytes(32);
-        const randomNewPessimisticRoot = computeRandomBytes(32);
-        const randomProof = computeRandomBytes(128);
+        const prevLocalExitRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const newLocalExitRoot = '0xa000000000000000000000000000000000000000000000000000000000000000';
+
+        const prevPessimisticRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const newPessimisticRoot = '0xb000000000000000000000000000000000000000000000000000000000000000';
+
+        const verifierAddress = '0x1000000000000000000000000000000000000000';
+        const l1InfoRoot = '0x1100000000000000000000000000000000000000000000000000000000000000';
+        const newArer = '0x2200000000000000000000000000000000000000000000000000000000000000';
+
+        const proof = `0x${''.padEnd(128 * 2, '0')}`;
         // append first 4 bytes to the proof to select the pessimistic vkey
-        const proofWithSelector = `${PESSIMISTIC_SELECTOR}${randomProof.slice(2)}`;
+        const proofWithSelector = `${PROOF_AGGREGATION_SELECTOR}${proof.slice(2)}`;
 
-        // Add default AggchainVKey
-        const aggchainVKey = computeRandomBytes(32);
+        // Add default proof aggregation vkey route
+        await aggLayerGatewayContract
+            .connect(addProofAggregationRoute)
+            .addProofAggregationVKeyRoute(AGGCHAIN_VKEY_SELECTOR, verifierAddress, proofAggregationVKey);
 
-        await expect(
-            aggLayerGatewayContract.connect(aggLayerAdmin).addDefaultAggchainVKey(AGGCHAIN_VKEY_SELECTOR, aggchainVKey),
-        )
-            .to.emit(aggLayerGatewayContract, 'AddDefaultAggchainVKey')
-            .withArgs(AGGCHAIN_VKEY_SELECTOR, aggchainVKey);
-
-        // verify pessimist proof with the new ECDSA Multisig rollup
+        // verify an aggregated proof of a single ECDSA aggchain
         const rollupECDSAMultisigData = await rollupManagerContract.rollupIDToRollupData(aggchainECDSAMultisigId);
         const aggchainECDSAMultisigFactory = await ethers.getContractFactory('AggchainECDSAMultisig');
         const ECDSAMultisigRollupContract = await aggchainECDSAMultisigFactory.attach(rollupECDSAMultisigData[0]);
 
         await expect(
-            rollupManagerContract.connect(trustedAggregator).verifyPessimisticTrustedAggregator(
-                aggchainECDSAMultisigId, // rollupID
-                1, // l1InfoTreeCount
-                randomNewLocalExitRoot,
-                randomNewPessimisticRoot,
-                proofWithSelector,
-                CUSTOM_DATA_ECDSA,
+            rollupManagerContract.connect(trustedAggregator).verifyAggregatedProofTrusted(
+                [
+                    {
+                        rollupID: aggchainECDSAMultisigId,
+                        newLocalExitRoot,
+                        newPessimisticRoot,
+                        aggchainData: CUSTOM_DATA_ECDSA,
+                    },
+                ],
+                l1InfoRoot, // rollupID
+                newArer, // l1InfoTreeCount
+                proofWithSelector, // proofBytes
             ),
         )
             .to.emit(rollupManagerContract, 'VerifyBatchesTrustedAggregator')
-            .to.emit(ECDSAMultisigRollupContract, 'OnVerifyPessimisticECDSAMultisig');
+            .to.emit(ECDSAMultisigRollupContract, 'OnVerifyPessimisticECDSAMultisig')
+            .to.emit(rollupManagerContract, 'VerifyAggregatedProof')
+            .withArgs(ethers.ZeroHash, newArer)
+            .to.emit(rollupManagerContract, 'VerifyPessimisticStateTransition')
+            .withArgs(
+                aggchainECDSAMultisigId,
+                prevPessimisticRoot,
+                newPessimisticRoot,
+                prevLocalExitRoot,
+                newLocalExitRoot,
+                l1InfoRoot,
+                trustedAggregator.address,
+            );
+    });
+
+    it('should verify an aggregated proof for multiple ECDSA aggchains', async () => {
+        // TODO: Implement this test
     });
 
     it('should add existing rollup to ECDSA', async () => {

--- a/test/contractsv2/PolygonRollupManagerAL-ECDSAMultisig.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-ECDSAMultisig.test.ts
@@ -533,7 +533,9 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
         const newPessimisticRoot = '0xb000000000000000000000000000000000000000000000000000000000000000';
 
         const verifierAddress = '0x1000000000000000000000000000000000000000';
-        const l1InfoRoot = '0x1100000000000000000000000000000000000000000000000000000000000000';
+        
+        const l1InfoTreeLeafCount = 1;
+        const l1InfoRoot = await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount);
         const newArer = '0x2200000000000000000000000000000000000000000000000000000000000000';
 
         const proof = `0x${''.padEnd(128 * 2, '0')}`;
@@ -563,7 +565,7 @@ describe('Polygon rollup manager aggregation layer v3: ECDSA Multisig', () => {
                         aggchainData: CUSTOM_DATA_ECDSA,
                     },
                 ],
-                l1InfoRoot,
+                l1InfoTreeLeafCount,
                 newArer,
                 proofWithSelector,
             ),

--- a/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
@@ -548,7 +548,9 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
         const newPessimisticRoot = '0xb000000000000000000000000000000000000000000000000000000000000000';
 
         const verifierAddress = '0x1000000000000000000000000000000000000000';
-        const l1InfoRoot = '0x1100000000000000000000000000000000000000000000000000000000000000';
+        
+        const l1InfoTreeLeafCount = 1;
+        const l1InfoRoot = await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount);
         const newArer = '0x2200000000000000000000000000000000000000000000000000000000000000';
 
         const proof = `0x${''.padEnd(128 * 2, '0')}`;
@@ -585,7 +587,7 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
                     aggchainData: CUSTOM_DATA_FEP,
                 },
             ],
-            l1InfoRoot,
+            l1InfoTreeLeafCount,
             newArer,
             proofWithSelector,
         );

--- a/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
@@ -53,13 +53,13 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
     // BRIDGE CONSTANTS
     const NETWORK_ID_MAINNET = 0;
     // AGGLAYER CONSTANTS
-    const PESSIMISTIC_SELECTOR = '0x00000001';
+    const PROOF_AGGREGATION_SELECTOR = '0x00000001';
     // calculate aggchainHash
     const newStateRoot = ethers.id('newStateRoot');
     const newl2BlockNumber = 1200;
     const aggchainVKeySelector = '0x12340001';
     const CUSTOM_DATA_FEP = encodeAggchainDataFEP(aggchainVKeySelector, newStateRoot, newl2BlockNumber);
-    const randomPessimisticVKey = computeRandomBytes(32);
+    const proofAggregationVKey = '0x1000000000000000000000000000000000000000000000000000000000000000';
     let initParams;
 
     upgrades.silenceWarnings();
@@ -206,9 +206,9 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
             aggLayerAdmin.address,
             aggLayerAdmin.address,
             aggLayerAdmin.address,
-            PESSIMISTIC_SELECTOR,
+            PROOF_AGGREGATION_SELECTOR,
             verifierContract.target,
-            randomPessimisticVKey,
+            proofAggregationVKey,
             admin.address, // multisigRole
             [], // signersToAdd
             0, // newThreshold
@@ -296,9 +296,9 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
                 aggLayerAdmin.address,
                 aggLayerAdmin.address,
                 aggLayerAdmin.address,
-                PESSIMISTIC_SELECTOR,
+                PROOF_AGGREGATION_SELECTOR,
                 verifierContract.target,
-                randomPessimisticVKey,
+                proofAggregationVKey,
                 admin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -517,7 +517,7 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
         expect(await aggchainFEPContract.getAggchainHash(CUSTOM_DATA_FEP)).to.be.equal(aggchainHashJS);
     });
 
-    it('should verify a pessimistic proof for a FEP aggchain', async () => {
+    it('should verify an aggregated proof of a single FEP aggchain', async () => {
         // Create FEP aggchain
         const rollupTypeIdFEP = await createFEPRollupType();
         const [aggchainFEPId, aggchainFEPAddress] = await createFEPRollup(rollupTypeIdFEP);
@@ -541,24 +541,20 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
 
         expect(await polygonZkEVMBridgeContract.depositCount()).to.be.equal(1);
 
-        // call rollup manager verify function
-        // Compute random values for proof generation
-        const randomNewLocalExitRoot = computeRandomBytes(32);
-        const randomNewPessimisticRoot = computeRandomBytes(32);
-        const randomProof = computeRandomBytes(128);
-        // append first 4 bytes to the proof to select the pessimistic vkey
-        const proofWithSelector = `${PESSIMISTIC_SELECTOR}${randomProof.slice(2)}`;
-        // expect to revert due to missing vkey (signers are already initialized in createFEPRollup)
-        await expect(
-            rollupManagerContract.connect(trustedAggregator).verifyPessimisticTrustedAggregator(
-                aggchainFEPId, // rollupID
-                1, // l1InfoTreeCount
-                randomNewLocalExitRoot,
-                randomNewPessimisticRoot,
-                proofWithSelector,
-                CUSTOM_DATA_FEP,
-            ),
-        ).to.be.revertedWithCustomError(aggLayerGatewayContract, 'AggchainVKeyNotFound');
+        const prevLocalExitRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const newLocalExitRoot = '0xa000000000000000000000000000000000000000000000000000000000000000';
+
+        const prevPessimisticRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const newPessimisticRoot = '0xb000000000000000000000000000000000000000000000000000000000000000';
+
+        const verifierAddress = '0x1000000000000000000000000000000000000000';
+        const l1InfoRoot = '0x1100000000000000000000000000000000000000000000000000000000000000';
+        const newArer = '0x2200000000000000000000000000000000000000000000000000000000000000';
+
+        const proof = `0x${''.padEnd(128 * 2, '0')}`;
+        // append first 4 bytes to the proof to select the proof aggregation vkey
+        const proofWithSelector = `${PROOF_AGGREGATION_SELECTOR}${proof.slice(2)}`;
+
         // Add default AggchainVKey
         const aggchainVKey = computeRandomBytes(32);
         await expect(
@@ -567,29 +563,50 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
             .to.emit(aggLayerGatewayContract, 'AddDefaultAggchainVKey')
             .withArgs(aggchainVKeySelector, aggchainVKey);
 
-        // verify pessimist proof with the new FEP rollup
-        const onVerifyPessimisticTx = await rollupManagerContract
-            .connect(trustedAggregator)
-            .verifyPessimisticTrustedAggregator(
-                aggchainFEPId, // rollupID
-                1, // l1InfoTreeCount
-                randomNewLocalExitRoot,
-                randomNewPessimisticRoot,
-                proofWithSelector,
-                CUSTOM_DATA_FEP,
-            );
+        // Add default proof aggregation vkey route
+        await aggLayerGatewayContract
+            .connect(aggLayerAdmin)
+            .addProofAggregationVKeyRoute(aggchainVKeySelector, verifierAddress, proofAggregationVKey);
 
-        const lastBlock = await ethers.provider.getBlock('latest');
-        const blockDataTimestamp = lastBlock?.timestamp;
-
+        // verify an aggregated proof of a single FEP aggchain
         const rollupFEPData = await rollupManagerContract.rollupIDToRollupData(aggchainFEPId);
         const aggchainFEPFactory = await ethers.getContractFactory('AggchainFEP');
         const FEPRollupContract = await aggchainFEPFactory.attach(rollupFEPData[0]);
 
-        await expect(onVerifyPessimisticTx)
+        const tx = await rollupManagerContract.connect(trustedAggregator).verifyAggregatedProofTrusted(
+            [
+                {
+                    rollupID: aggchainFEPId,
+                    newLocalExitRoot,
+                    newPessimisticRoot,
+                    aggchainData: CUSTOM_DATA_FEP,
+                },
+            ],
+            l1InfoRoot,
+            newArer,
+            proofWithSelector,
+        );
+
+        const receipt = await tx.wait();
+        const block = await ethers.provider.getBlock(receipt?.blockNumber || 0);
+        const blockDataTimestamp = block?.timestamp;
+
+        await expect(tx)
             .to.emit(rollupManagerContract, 'VerifyBatchesTrustedAggregator')
             .to.emit(FEPRollupContract, 'OutputProposed')
-            .withArgs(newStateRoot, 1, newl2BlockNumber, blockDataTimestamp);
+            .withArgs(newStateRoot, 1, newl2BlockNumber, blockDataTimestamp)
+            .to.emit(rollupManagerContract, 'VerifyAggregatedProof')
+            .withArgs(ethers.ZeroHash, newArer)
+            .to.emit(rollupManagerContract, 'VerifyPessimisticStateTransition')
+            .withArgs(
+                aggchainFEPId,
+                prevPessimisticRoot,
+                newPessimisticRoot,
+                prevLocalExitRoot,
+                newLocalExitRoot,
+                l1InfoRoot,
+                trustedAggregator.address,
+            );
     });
 
     it('should add existing rollup to FEP', async () => {

--- a/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
+++ b/test/contractsv2/PolygonRollupManagerAL-FEP.test.ts
@@ -573,6 +573,9 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
         const aggchainFEPFactory = await ethers.getContractFactory('AggchainFEP');
         const FEPRollupContract = await aggchainFEPFactory.attach(rollupFEPData[0]);
 
+        // Check initial value of lastAgglayerRollupExitRoot (should be zero)
+        expect(await rollupManagerContract.lastAgglayerRollupExitRoot()).to.be.equal(ethers.ZeroHash);
+
         const tx = await rollupManagerContract.connect(trustedAggregator).verifyAggregatedProofTrusted(
             [
                 {
@@ -588,8 +591,19 @@ describe('Polygon rollup manager aggregation layer v3: FEP', () => {
         );
 
         const receipt = await tx.wait();
+        
+        // Assert that lastAgglayerRollupExitRoot is updated to newArer
+        expect(await rollupManagerContract.lastAgglayerRollupExitRoot()).to.be.equal(newArer);
+        
+        // Assert that rollup's lastLocalExitRoot and lastPessimisticRoot are updated
+        const rollupDataAfter = await rollupManagerContract.rollupIDToRollupDataV2(aggchainFEPId);
+        expect(rollupDataAfter.lastLocalExitRoot).to.be.equal(newLocalExitRoot);
+        expect(rollupDataAfter.lastPessimisticRoot).to.be.equal(newPessimisticRoot);
+        
         const block = await ethers.provider.getBlock(receipt?.blockNumber || 0);
         const blockDataTimestamp = block?.timestamp;
+
+        
 
         await expect(tx)
             .to.emit(rollupManagerContract, 'VerifyBatchesTrustedAggregator')

--- a/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
@@ -23,8 +23,6 @@ import {
 import { NO_ADDRESS, AGGCHAIN_DEFAULT_VKEY_ROLE, AL_ADD_PP_ROUTE_ROLE, AL_MULTISIG_ROLE } from '../../src/constants';
 import { VerifierType, computeRandomBytes } from '../../src/pessimistic-utils';
 
-const randomPessimisticVKey = computeRandomBytes(32);
-
 describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
     // SIGNERS
     let deployer: any;
@@ -37,8 +35,8 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
     let aggLayerAdmin: any;
     let tester: any;
     let aggchainVKey: any;
-    let addPPRoute: any;
-    let freezePPRoute: any;
+    let addProofAggregationRoute: any;
+    let freezeProofAggregationRoute: any;
 
     // CONTRACTS
     let polygonZkEVMBridgeContract: AgglayerBridge;
@@ -58,12 +56,13 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
     // BRIDGE CONSTANTS
     const NETWORK_ID_MAINNET = 0;
     // AGGLAYER CONSTANTS
-    const PESSIMISTIC_SELECTOR = '0x00000001';
+    const PROOF_AGGREGATION_SELECTOR = '0x00000001';
     // AGGCHAIN CONSTANTS
     // bytes2(version)=0x0001 | bytes2(type)=0x0002 => selector 0x00010002
     const AGGCHAIN_VKEY_SELECTOR = '0x00010002';
     const randomNewStateRoot = computeRandomBytes(32);
     const CUSTOM_DATA_ECDSA = '0x'; // ECDSA Multisig expects empty aggchainData
+    const proofAggregationVKey = '0x1000000000000000000000000000000000000000000000000000000000000000';
     upgrades.silenceWarnings();
 
     async function createAggchainRollupType(implementationContract: any) {
@@ -244,8 +243,8 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
             aggLayerAdmin,
             tester,
             aggchainVKey,
-            addPPRoute,
-            freezePPRoute,
+            addProofAggregationRoute,
+            freezeProofAggregationRoute,
         ] = await ethers.getSigners();
 
         // Deploy L1 contracts
@@ -280,11 +279,11 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
         await aggLayerGatewayContract.initialize(
             admin.address,
             aggchainVKey.address,
-            addPPRoute.address,
-            freezePPRoute.address,
-            PESSIMISTIC_SELECTOR,
+            addProofAggregationRoute.address,
+            freezeProofAggregationRoute.address,
+            PROOF_AGGREGATION_SELECTOR,
             verifierContract.target,
-            randomPessimisticVKey,
+            proofAggregationVKey,
             admin.address, // multisigRole
             [], // signersToAdd
             0, // newThreshold
@@ -418,11 +417,11 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
             aggLayerGatewayContract.initialize(
                 timelock.address,
                 aggchainVKey.address,
-                addPPRoute.address,
-                freezePPRoute.address,
-                PESSIMISTIC_SELECTOR,
+                addProofAggregationRoute.address,
+                freezeProofAggregationRoute.address,
+                PROOF_AGGREGATION_SELECTOR,
                 verifierContract.target,
-                randomPessimisticVKey,
+                proofAggregationVKey,
                 admin.address, // multisigRole
                 [], // signersToAdd
                 0, // newThreshold
@@ -541,28 +540,70 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
 
         expect(await polygonZkEVMBridgeContract.depositCount()).to.be.equal(1);
 
-        // call rollup manager verify function
-        // Compute random values for proof generation
-        const randomNewLocalExitRoot = computeRandomBytes(32);
-        const randomNewPessimisticRoot = computeRandomBytes(32);
-        const randomProof = computeRandomBytes(128);
-        // append first 4 bytes to the proof to select the pessimistic vkey
-        const proofWithSelector = `${PESSIMISTIC_SELECTOR}${randomProof.slice(2)}`;
+        const prevLocalExitRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const newLocalExitRoot = '0xa000000000000000000000000000000000000000000000000000000000000000';
 
-        // verify pessimist proof with the new ECDSA rollup
-        expect(
-            await rollupManagerContract.connect(trustedAggregator).verifyPessimisticTrustedAggregator(
-                aggchainECDSAId, // rollupID
-                1, // l1InfoTreeCount
-                randomNewLocalExitRoot,
-                randomNewPessimisticRoot,
+        const prevPessimisticRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
+        const newPessimisticRoot = '0xb000000000000000000000000000000000000000000000000000000000000000';
+
+        const verifierAddress = '0x1000000000000000000000000000000000000000';
+        const l1InfoRoot = '0x1100000000000000000000000000000000000000000000000000000000000000';
+        const newArer = '0x2200000000000000000000000000000000000000000000000000000000000000';
+
+        const proof = `0x${''.padEnd(128 * 2, '0')}`;
+        // append first 4 bytes to the proof to select the proof aggregation vkey
+        const proofWithSelector = `${PROOF_AGGREGATION_SELECTOR}${proof.slice(2)}`;
+
+        // Add default proof aggregation vkey route
+        await aggLayerGatewayContract
+            .connect(addProofAggregationRoute)
+            .addProofAggregationVKeyRoute(AGGCHAIN_VKEY_SELECTOR, verifierAddress, proofAggregationVKey);
+
+        // verify an aggregated proof of a single ECDSA aggchain
+        const rollupECDSAData = await rollupManagerContract.rollupIDToRollupData(aggchainECDSAId);
+        const aggchainECDSAFactory = await ethers.getContractFactory('AggchainECDSAMultisig');
+        const ECDSARollupContract = await aggchainECDSAFactory.attach(rollupECDSAData[0]);
+
+        // Check initial value of lastAgglayerRollupExitRoot (should be zero)
+        expect(await rollupManagerContract.lastAgglayerRollupExitRoot()).to.be.equal(ethers.ZeroHash);
+
+        await expect(
+            rollupManagerContract.connect(trustedAggregator).verifyAggregatedProofTrusted(
+                [
+                    {
+                        rollupID: aggchainECDSAId,
+                        newLocalExitRoot,
+                        newPessimisticRoot,
+                        aggchainData: CUSTOM_DATA_ECDSA,
+                    },
+                ],
+                l1InfoRoot,
+                newArer,
                 proofWithSelector,
-                CUSTOM_DATA_ECDSA,
             ),
         )
             .to.emit(rollupManagerContract, 'VerifyBatchesTrustedAggregator')
-            .to.emit(aggchainECDSAImplementationContract, 'OnVerifyPessimistic')
-            .withArgs(randomNewStateRoot);
+            .to.emit(ECDSARollupContract, 'OnVerifyPessimisticECDSAMultisig')
+            .to.emit(rollupManagerContract, 'VerifyAggregatedProof')
+            .withArgs(ethers.ZeroHash, newArer)
+            .to.emit(rollupManagerContract, 'VerifyPessimisticStateTransition')
+            .withArgs(
+                aggchainECDSAId,
+                prevPessimisticRoot,
+                newPessimisticRoot,
+                prevLocalExitRoot,
+                newLocalExitRoot,
+                l1InfoRoot,
+                trustedAggregator.address,
+            );
+
+        // Assert that lastAgglayerRollupExitRoot is updated to newArer
+        expect(await rollupManagerContract.lastAgglayerRollupExitRoot()).to.be.equal(newArer);
+        
+        // Assert that rollup's lastLocalExitRoot and lastPessimisticRoot are updated
+        const rollupDataAfter = await rollupManagerContract.rollupIDToRollupDataV2(aggchainECDSAId);
+        expect(rollupDataAfter.lastLocalExitRoot).to.be.equal(newLocalExitRoot);
+        expect(rollupDataAfter.lastPessimisticRoot).to.be.equal(newPessimisticRoot);
     });
 
     it('should add existing rollup to ECDSA', async () => {

--- a/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
@@ -365,7 +365,7 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
             ),
         )
             .to.emit(rollupManagerContract, 'UpdateRollupManagerVersion')
-            .withArgs('v1.0.0');
+            .withArgs('v2.0.0');
 
         // check precalculated address
         expect(precalculateRollupManagerAddress).to.be.equal(rollupManagerContract.target);

--- a/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerALUpgrade.test.ts
@@ -547,7 +547,9 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
         const newPessimisticRoot = '0xb000000000000000000000000000000000000000000000000000000000000000';
 
         const verifierAddress = '0x1000000000000000000000000000000000000000';
-        const l1InfoRoot = '0x1100000000000000000000000000000000000000000000000000000000000000';
+        
+        const l1InfoTreeLeafCount = 1;
+        const l1InfoRoot = await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount);
         const newArer = '0x2200000000000000000000000000000000000000000000000000000000000000';
 
         const proof = `0x${''.padEnd(128 * 2, '0')}`;
@@ -577,7 +579,7 @@ describe('Polygon rollup manager aggregation layer v3 UPGRADED', () => {
                         aggchainData: CUSTOM_DATA_ECDSA,
                     },
                 ],
-                l1InfoRoot,
+                l1InfoTreeLeafCount,
                 newArer,
                 proofWithSelector,
             ),

--- a/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
@@ -98,7 +98,7 @@ describe('Polygon Rollup manager upgraded', () => {
     let polygonZkEVMGlobalExitRoot: AgglayerGER;
     let rollupManagerContract: AgglayerManagerMock;
 
-    const latestVersionRollupManager = 'v1.0.0';
+    const latestVersionRollupManager = 'v2.0.0';
     const polTokenName = 'POL Token';
     const polTokenSymbol = 'POL';
     const polTokenInitialBalance = ethers.parseEther('20000000');

--- a/test/contractsv2/UpgradeToPP.test.ts
+++ b/test/contractsv2/UpgradeToPP.test.ts
@@ -438,13 +438,18 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
         await expect(
             rollupManagerContract
                 .connect(trustedAggregator)
-                .verifyPessimisticTrustedAggregator(
-                    newCreatedRollupID,
-                    lastL1InfoTreeLeafCount,
-                    newWrongLER,
-                    newPPRoot,
+                .verifyAggregatedProofTrusted(
+                    [
+                        {
+                            rollupID: newCreatedRollupID,
+                            newLocalExitRoot: newWrongLER,
+                            newPessimisticRoot: newPPRoot,
+                            aggchainData: CUSTOM_DATA_ECDSA,
+                        },
+                    ],
+                    await polygonZkEVMGlobalExitRoot.l1InfoRootMap(lastL1InfoTreeLeafCount),
+                    ethers.ZeroHash,
                     proofWithSelector,
-                    CUSTOM_DATA_ECDSA,
                 ),
         ).to.be.revertedWithCustomError(rollupManagerContract, 'InvalidNewLocalExitRoot');
 
@@ -457,13 +462,18 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
         await expect(
             rollupManagerContract
                 .connect(trustedAggregator)
-                .verifyPessimisticTrustedAggregator(
-                    newCreatedRollupID,
-                    lastL1InfoTreeLeafCount,
-                    lastLER,
-                    newPPRoot,
+                .verifyAggregatedProofTrusted(
+                    [
+                        {
+                            rollupID: newCreatedRollupID,
+                            newLocalExitRoot: lastLER,
+                            newPessimisticRoot: newPPRoot,
+                            aggchainData: CUSTOM_DATA_ECDSA,
+                        },
+                    ],
+                    lastL1InfoTreeRoot,
+                    ethers.ZeroHash,
                     proofWithSelector,
-                    CUSTOM_DATA_ECDSA,
                 ),
         )
             .to.emit(rollupManagerContract, 'CompletedMigration')

--- a/test/contractsv2/UpgradeToPP.test.ts
+++ b/test/contractsv2/UpgradeToPP.test.ts
@@ -427,8 +427,10 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
 
         expect(await rollupManagerContract.isRollupMigrating(newCreatedRollupID)).to.be.equal(true);
 
+        const l1InfoRoot = await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount);
+
         // Verify PP with mock "bootstrapBatch"
-        const lastL1InfoTreeLeafCount = await polygonZkEVMGlobalExitRoot.depositCount();
+        
         const newWrongLER = '0x0000000000000000000000000000000000000000000000000000000000000001';
         const lastLER = rollupData[4];
         const newPPRoot = computeRandomBytes(32);
@@ -447,7 +449,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
                             aggchainData: CUSTOM_DATA_ECDSA,
                         },
                     ],
-                    await polygonZkEVMGlobalExitRoot.l1InfoRootMap(lastL1InfoTreeLeafCount),
+                    l1InfoTreeLeafCount,
                     ethers.ZeroHash,
                     proofWithSelector,
                 ),
@@ -458,7 +460,6 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
 
         const prevPP = ethers.ZeroHash;
         const prevLER = ethers.ZeroHash;
-        const lastL1InfoTreeRoot = await polygonZkEVMGlobalExitRoot.l1InfoRootMap(lastL1InfoTreeLeafCount);
         await expect(
             rollupManagerContract
                 .connect(trustedAggregator)
@@ -471,7 +472,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
                             aggchainData: CUSTOM_DATA_ECDSA,
                         },
                     ],
-                    lastL1InfoTreeRoot,
+                    l1InfoTreeLeafCount,
                     ethers.ZeroHash,
                     proofWithSelector,
                 ),
@@ -487,7 +488,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
                 newPPRoot,
                 prevLER,
                 lastLER,
-                lastL1InfoTreeRoot,
+                l1InfoRoot,
                 trustedAggregator.address,
             );
 

--- a/test/contractsv2/real-prover-sp1/e2e-verify-proof.test.ts
+++ b/test/contractsv2/real-prover-sp1/e2e-verify-proof.test.ts
@@ -315,25 +315,26 @@ describe('Polygon Rollup Manager with zkevm etrog migration to ECDSA Multisig wi
 
         // Verify migration completed successfully for ECDSA Multisig
         // For ECDSA Multisig, verification is simpler - just verify the migration completed
-        const currentDepositCount = await polygonZkEVMGlobalExitRoot.depositCount();
-        const l1InfoTreeLeafCount = Number(currentDepositCount) + 1;
+        const l1InfoTreeLeafCount = 1;
+        const l1InfoRoot = await polygonZkEVMGlobalExitRoot.l1InfoRootMap(l1InfoTreeLeafCount);
         const newLER = ethers.ZeroHash; // For ECDSA multisig with no bridges
         const newPPRoot = inputZkevmMigration.pp_inputs.new_pessimistic_root;
         const proofPP = inputZkevmMigration.proof;
-        const l1InfoRoot = inputZkevmMigration.pp_inputs.l1_info_root;
 
-        // Mock selected GER for the migration
-        await polygonZkEVMGlobalExitRoot.injectGER(l1InfoRoot, l1InfoTreeLeafCount);
-
-        // Finalize the migration with verifyPessimisticTrustedAggregator (no bridges)
+        // Finalize the migration with verifyAggregatedProofTrusted (no bridges)
         await expect(
-            rollupManagerContract.connect(trustedAggregator).verifyPessimisticTrustedAggregator(
-                newCreatedRollupID,
+            rollupManagerContract.connect(trustedAggregator).verifyAggregatedProofTrusted(
+                [
+                    {
+                        rollupID: newCreatedRollupID,
+                        newLocalExitRoot: newLER,
+                        newPessimisticRoot: newPPRoot,
+                        aggchainData: '0x', // aggchainData is empty for ECDSA multisig
+                    },
+                ],
                 l1InfoTreeLeafCount,
-                newLER,
-                newPPRoot,
+                ethers.ZeroHash,
                 proofPP,
-                '0x', // aggchainData is empty for ECDSA multisig
             ),
         )
             .to.emit(rollupManagerContract, 'CompletedMigration')


### PR DESCRIPTION
WIP: Do not merge.

Notes (to be organized):
* This PR introduces support for proof aggregation, which allows to verify multiple aggchain state transitions in a single call, verifying an aggregated proof.
* The proof aggregation route logic from the `AgglayerGateway` reuses the storage slot of the deprecated PP route. Some types are reused as well. Roles are reused as well and names are not changed to avoid breaking changes. See comments.
* This PR introduces breaking changes. Old proofs will no longer verify. The function `verifyPessimisticTrustedAggregator` no longer exists and now `verifyAggregatedProofTrusted` shall be used. This new function wont work with PolygonPessimisticConsensus, as that path is deprecated as well.
* New versions:
  * `AgglayerGateway` = `v2.0.0`
  * `AgglayerManager` = `v2.0.0`
* A new event is introduced:
  * `VerifyAggregatedProof(bytes32 indexed prevArer, bytes32 indexed newArer)`


TODO:
- [x] Finish implementation
- [ ] Tests
  - [x] Fix existing tests
  - [ ] Fix test with real prover
  - [ ] Test upgrades
  - [ ] Test multi proofs (mocked/real)
- [ ] Initialize lastAgglayerRollupExitRoot
