### PR TITLE
test(foundry): fix Foundry test base

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,6 +12,9 @@ fs_permissions = [
 
 remappings = ["forge-std/=dependencies/forge-std-1.10.0/src/"]
 
+[lint]
+lint_on_build = false
+
 [profile.coverage]
 src = "contracts"
 libs = ["dependencies", "node_modules"]

--- a/test/forge/base/BaseTest.t.sol
+++ b/test/forge/base/BaseTest.t.sol
@@ -29,6 +29,7 @@ import {Constants} from "test/forge/utils/Constants.sol";
  * @title BaseTest
  * @dev Base contract for foundry tests. Contains setUp function and deployment utilities.
  */
+// @remind This is a provisional setup to facilitate testing. Actual deployment and testing methods may differ depending on the type of tests being conducted.
 abstract contract BaseTest is Test {
     string internal constant POLYGON_ZKEVM_DEPLOYER_ARTIFACT_PATH =
         "artifacts/contracts/deployment/PolygonZkEVMDeployer.sol/PolygonZkEVMDeployer.json";
@@ -72,8 +73,8 @@ abstract contract BaseTest is Test {
      * 5. Timelock gets ownership of ProxyAdmin for governance
      */
     function setUp() public virtual {
-        // 1. Etch PolygonZkEVMDeployer bytecode from Hardhat artifacts
-        deployer = _etchPolygonZkEVMDeployer(owner);
+        // 1. Deploy PolygonZkEVMDeployer bytecode from Hardhat artifacts
+        deployer = deployCode(POLYGON_ZKEVM_DEPLOYER_ARTIFACT_PATH, abi.encode(owner));
 
         // 2. Etch AgglayerTimelock bytecode from Hardhat artifacts
         address[] memory proposers = new address[](1);
@@ -81,9 +82,11 @@ abstract contract BaseTest is Test {
         proposers[0] = timelockProposer;
         executors[0] = timelockExecutor;
 
-        // Use etching function to deploy timelock with immutable modification
-        // Setting agglayerManager to address(0) to skip emergency state check in getMinDelay()
-        timelock = _etchAgglayerTimelock(Constants.TIMELOCK_MIN_DELAY, proposers, executors, address(0));
+        // Deploy AgglayerTimelock with deployCode and constructor args
+        timelock = deployCode(
+            AGGLAYER_TIMELOCK_ARTIFACT_PATH,
+            abi.encode(Constants.TIMELOCK_MIN_DELAY, proposers, executors, owner, owner)
+        );
 
         // @todo Interdependencies setup (e.g. set rollup manager address in AgglayerGER)
         // @todo Setup mocks for more complex deployments
@@ -182,7 +185,7 @@ abstract contract BaseTest is Test {
      */
     function deployAgglayerGER() public returns (AgglayerGER) {
         // === AGGLAYERGER IMPLEMENTATION DEPLOYMENT ===
-        agglayerGERImpl = new AgglayerGER(Constants.ROLLUP_MANAGER_ADDRESS, Constants.BRIDGE_ADDRESS);
+        agglayerGERImpl = new AgglayerGER(Constants.ROLLUP_MANAGER_ADDRESS, address(agglayerBridge));
 
         // === AGGLAYERGER PROXY DEPLOYMENT ===
         bytes memory initData = abi.encodeCall(AgglayerGER.initialize, ());
@@ -213,6 +216,7 @@ abstract contract BaseTest is Test {
      */
     function deployAgglayerManager() public returns (AgglayerManager) {
         // === AGGLAYERMANAGER IMPLEMENTATION DEPLOYMENT ===
+        // @todo Update constructor args according to actual deployment
         agglayerManagerImpl = new AgglayerManager(
             IAgglayerGER(Constants.GER_MANAGER_ADDRESS),
             IERC20Upgradeable(Constants.POL_TOKEN_ADDRESS),
@@ -259,188 +263,6 @@ abstract contract BaseTest is Test {
             IAgglayerGateway(Constants.AGGLAYER_GATEWAY_ADDRESS)
         );
         return aggchainECDSAImpl;
-    }
-
-    /**
-     * @dev Etch PolygonZkEVMDeployer bytecode from Hardhat artifacts
-     * @param _owner The owner address for the deployer
-     * @return deployerAddress The address where the deployer was etched
-     */
-    function _etchPolygonZkEVMDeployer(address _owner) internal returns (address) {
-        // Read the deployedBytecode from Hardhat artifacts
-        string memory artifact = vm.readFile(POLYGON_ZKEVM_DEPLOYER_ARTIFACT_PATH);
-        bytes memory deployedBytecode = vm.parseJsonBytes(artifact, ".deployedBytecode");
-
-        // Generate a deterministic address for the deployer
-        address deployerAddress = makeAddr("PolygonZkEVMDeployer");
-
-        // Etch the bytecode at the address
-        vm.etch(deployerAddress, deployedBytecode);
-
-        // Set the owner storage slot (slot 0 in Ownable)
-        vm.store(deployerAddress, bytes32(uint256(0)), bytes32(uint256(uint160(_owner))));
-
-        return deployerAddress;
-    }
-
-    /**
-     * @dev Etch AgglayerTimelock bytecode from Hardhat artifacts with immutable replacement
-     * @param _minDelay Minimum delay for timelock operations
-     * @param _proposers Array of proposer addresses
-     * @param _executors Array of executor addresses
-     * @param _agglayerManagerAddr The agglayer manager contract (used for emergency state)
-     * @return timelockAddress The address where the timelock was etched
-     */
-    function _etchAgglayerTimelock(
-        uint256 _minDelay,
-        address[] memory _proposers,
-        address[] memory _executors,
-        address _agglayerManagerAddr
-    ) internal returns (address) {
-        // Read the deployedBytecode from Hardhat artifacts
-        string memory artifact = vm.readFile(AGGLAYER_TIMELOCK_ARTIFACT_PATH);
-        bytes memory deployedBytecode = vm.parseJsonBytes(artifact, ".deployedBytecode");
-
-        // Replace the immutable agglayerManager placeholder with the actual address
-        // The immutable is stored as PUSH32 with 12 bytes padding + 20 bytes address
-        // Pattern: 7f + 000000000000000000000000 (12 bytes) + 00000000000000000000000000000000000000000000 (20 bytes)
-        bytes memory modifiedBytecode = _replaceImmutableInPush32(deployedBytecode, _agglayerManagerAddr);
-
-        // Generate a deterministic address for the timelock
-        address timelockAddress = makeAddr("AgglayerTimelock");
-
-        // Etch the modified bytecode at the address
-        vm.etch(timelockAddress, modifiedBytecode);
-
-        // Set up storage for timelock state
-        _setupTimelockStorage(timelockAddress, _minDelay, _proposers, _executors);
-
-        // Test whether the addresses are set properly or not
-        bytes memory result;
-        (, result) = timelockAddress.call(abi.encodeWithSignature("agglayerManager()"));
-        address agglayerManagerAddr = abi.decode(result, (address));
-        require(agglayerManagerAddr == _agglayerManagerAddr, "AgglayerTimelock: Agglayer Manager replacement failed");
-
-        (, result) = timelockAddress.call(abi.encodeWithSignature("getMinDelay()"));
-        uint256 actualMinDelay = abi.decode(result, (uint256));
-        require(actualMinDelay == _minDelay, "AgglayerTimelock: MinDelay not set correctly");
-
-        bytes32 proposerRole = keccak256("PROPOSER_ROLE");
-        for (uint256 i = 0; i < _proposers.length; i++) {
-            (, result) =
-                timelockAddress.call(abi.encodeWithSignature("hasRole(bytes32,address)", proposerRole, _proposers[i]));
-            bool hasProposerRole = abi.decode(result, (bool));
-            require(hasProposerRole, "AgglayerTimelock: Proposer role not set correctly");
-        }
-
-        bytes32 executorRole = keccak256("EXECUTOR_ROLE");
-        for (uint256 i = 0; i < _executors.length; i++) {
-            (, result) =
-                timelockAddress.call(abi.encodeWithSignature("hasRole(bytes32,address)", executorRole, _executors[i]));
-            bool hasExecutorRole = abi.decode(result, (bool));
-            require(hasExecutorRole, "AgglayerTimelock: Executor role not set correctly");
-        }
-
-        return timelockAddress;
-    }
-
-    /**
-     * @dev Setup storage for AgglayerTimelock after etching bytecode
-     * This replicates what the TimelockController constructor does
-     * @param _timelockAddress The address where timelock was etched
-     * @param _minDelay Minimum delay for timelock operations
-     * @param _proposers Array of proposer addresses
-     * @param _executors Array of executor addresses
-     */
-    function _setupTimelockStorage(
-        address _timelockAddress,
-        uint256 _minDelay,
-        address[] memory _proposers,
-        address[] memory _executors
-    ) internal {
-        // Role constants from OpenZeppelin TimelockController
-        bytes32 timelockAdminRole = keccak256("TIMELOCK_ADMIN_ROLE");
-        bytes32 proposerRole = keccak256("PROPOSER_ROLE");
-        bytes32 executorRole = keccak256("EXECUTOR_ROLE");
-        bytes32 cancellerRole = keccak256("CANCELLER_ROLE");
-
-        // 1. Give timelock self-administration (constructor calls _setupRole(TIMELOCK_ADMIN_ROLE, address(this)))
-        _grantRoleStorage(_timelockAddress, timelockAdminRole, _timelockAddress);
-
-        // 2. Grant proposer and canceller roles to proposers
-        for (uint256 i = 0; i < _proposers.length; i++) {
-            _grantRoleStorage(_timelockAddress, proposerRole, _proposers[i]);
-            _grantRoleStorage(_timelockAddress, cancellerRole, _proposers[i]);
-        }
-
-        // 3. Grant executor role to executor
-        for (uint256 i = 0; i < _executors.length; i++) {
-            _grantRoleStorage(_timelockAddress, executorRole, _executors[i]);
-        }
-
-        // 4. Set minDelay in storage slot 2
-        vm.store(_timelockAddress, bytes32(uint256(2)), bytes32(_minDelay));
-    }
-
-    /**
-     * @dev Grant a role to an account by setting storage directly
-     * @param _contract The contract address
-     * @param _role The role hash
-     * @param _account The account to grant the role to
-     */
-    function _grantRoleStorage(address _contract, bytes32 _role, address _account) internal {
-        // Calculate storage position: keccak256(abi.encode(role, slot)) for the RoleData struct
-        bytes32 roleDataSlot = keccak256(abi.encode(_role, uint256(0)));
-
-        // Calculate storage position for account: keccak256(abi.encode(account, roleDataSlot))
-        bytes32 accountSlot = keccak256(abi.encode(_account, roleDataSlot));
-
-        // Set the account as having the role (true = 0x01)
-        vm.store(_contract, accountSlot, bytes32(uint256(1)));
-    }
-
-    /**
-     * @dev Replace an immutable address in a PUSH32 instruction
-     * Solidity immutables for addresses are stored as PUSH32 with 12 bytes padding
-     * @param _bytecode The original bytecode
-     * @param _actual The actual address to set
-     * @return The modified bytecode
-     */
-    function _replaceImmutableInPush32(bytes memory _bytecode, address _actual) internal pure returns (bytes memory) {
-        // Pattern to search for: PUSH32 (0x7f) + 12 zero bytes + 20 zero bytes (address)
-        bytes memory searchPattern = abi.encodePacked(
-            bytes1(0x7f), // PUSH32 opcode
-            bytes12(0), // 12 bytes padding
-            bytes20(0) // 20 bytes zero address (placeholder)
-        );
-
-        // Replacement: PUSH32 (0x7f) + 12 zero bytes + actual address
-        bytes memory replacement = abi.encodePacked(
-            bytes1(0x7f), // PUSH32 opcode
-            bytes12(0), // 12 bytes padding
-            bytes20(uint160(_actual)) // 20 bytes actual address
-        );
-
-        // Search for the pattern (33 bytes: 1 + 12 + 20)
-        for (uint256 i = 0; i <= _bytecode.length - 33; i++) {
-            bool isMatch = true;
-            for (uint256 j = 0; j < 33; j++) {
-                if (_bytecode[i + j] != searchPattern[j]) {
-                    isMatch = false;
-                    break;
-                }
-            }
-
-            if (isMatch) {
-                // Replace the pattern with the actual address
-                for (uint256 j = 0; j < 33; j++) {
-                    _bytecode[i + j] = replacement[j];
-                }
-                // Continue searching for more occurrences (immutable might appear multiple times)
-            }
-        }
-
-        return _bytecode;
     }
 
     /// @notice Create and deploy a proxy contract

--- a/test/forge/fuzz/AgglayerGERFuzz.t.sol
+++ b/test/forge/fuzz/AgglayerGERFuzz.t.sol
@@ -17,7 +17,7 @@ contract AgglayerGERFuzz is BaseTest {
 
     function testFuzz_RevertIf_nonBridgeOrRollupManager_updateExitRoot(address caller, bytes32 newRoot) public {
         // @todo change addresses according to the setup in BaseTest once updated
-        vm.assume(caller != Constants.BRIDGE_ADDRESS && caller != Constants.ROLLUP_MANAGER_ADDRESS);
+        vm.assume(caller != Constants.BRIDGE_ADDRESS && caller != Constants.ROLLUP_MANAGER_ADDRESS && caller != address(proxyAdmin));
 
         vm.expectRevert(abi.encodeWithSelector(IBaseLegacyAgglayerGER.OnlyAllowedContracts.selector));
 


### PR DESCRIPTION
This pull request refactors the Foundry test setup to simplify contract deployment in `BaseTest.t.sol`, moving away from manual bytecode etching to using constructor-based deployment. It also updates some deployment arguments and adds clarifying comments for future improvements.