### PR TITLE
Move duplicated functions to utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -191,3 +191,71 @@ export function getGitInfo(criticalTooling = false): { commit: string; repo: str
         throw new Error(`getGitInfo: ${error}`);
     }
 }
+
+/**
+ * Calculates the global exit root for a given mainnet exit root and rollup exit root
+ * @param {String} mainnetExitRoot - the mainnet exit root
+ * @param {String} rollupExitRoot - the rollup exit root
+ * @returns {String} the global exit root
+ */
+export function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
+    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
+}
+
+/**
+ * Calculates the global exit root leaf for a given global exit root, last block hash and timestamp
+ * @param {String} newGlobalExitRoot - the new global exit root
+ * @param {String} lastBlockHash - the last block hash
+ * @param {Number} timestamp - the timestamp
+ * @returns {String} the global exit root leaf
+ */
+export function calculateGlobalExitRootLeaf(newGlobalExitRoot: any, lastBlockHash: any, timestamp: any) {
+    return ethers.solidityPackedKeccak256(
+        ['bytes32', 'bytes32', 'uint64'],
+        [newGlobalExitRoot, lastBlockHash, timestamp],
+    );
+}
+
+/**
+ * Compute accumulateInputHash = Keccak256(oldAccInputHash, batchHashData, l1InfoTreeRoot, timestamp, seqAddress)
+ * @param {String} oldAccInputHash - old accumulateInputHash
+ * @param {String} batchHashData - Batch hash data
+ * @param {String} l1InfoTreeRoot - L1 info tree root
+ * @param {Number} timestamp - Block timestamp
+ * @param {String} sequencerAddress - Sequencer address
+ * @param {String} forcedBlockHash - Forced block hash
+ * @returns {String} - accumulateInputHash in hex encoding
+ */
+export function calculateAccInputHashetrog(
+    oldAccInputHash: any,
+    batchHashData: any,
+    l1InfoTreeRoot: any,
+    timestamp: any,
+    sequencerAddress: any,
+    forcedBlockHash: any,
+) {
+    const hashKeccak = ethers.solidityPackedKeccak256(
+        ['bytes32', 'bytes32', 'bytes32', 'uint64', 'address', 'bytes32'],
+        [oldAccInputHash, batchHashData, l1InfoTreeRoot, timestamp, sequencerAddress, forcedBlockHash],
+    );
+
+    return hashKeccak;
+}
+
+/**
+ * Computes the global index for a given index local and index rollup
+ * @param {Number} indexLocal - the index local
+ * @param {Number} indexRollup - the index rollup
+ * @param {Boolean} isMainnet - whether the index is for the mainnet
+ * @returns {BigInt} the global index
+ */
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
+
+export function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
+    if (isMainnet === true) {
+        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
+    }
+    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
+}

--- a/test/contractsv2/BridgeL2GasTokenMappedSovereignChains.test.ts
+++ b/test/contractsv2/BridgeL2GasTokenMappedSovereignChains.test.ts
@@ -4,22 +4,10 @@ import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { setBalance } from '@nomicfoundation/hardhat-network-helpers';
 import { ERC20PermitMock, AgglayerGERL2, AgglayerBridgeL2, TokenWrapped } from '../../typechain-types';
 import { computeWrappedTokenProxyAddress, claimBeforeBridge } from './helpers/helpers-sovereign-bridge';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 describe('SovereignChainBridge Gas tokens mapped tests', () => {
     upgrades.silenceWarnings();

--- a/test/contractsv2/BridgeL2GasTokensSovereignChains.test.ts
+++ b/test/contractsv2/BridgeL2GasTokensSovereignChains.test.ts
@@ -4,21 +4,10 @@ import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { setBalance } from '@nomicfoundation/hardhat-network-helpers';
 import { ERC20PermitMock, AgglayerGERL2, AgglayerBridgeL2, TokenWrapped } from '../../typechain-types';
 import { claimBeforeBridge, computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 describe('SovereignChainBridge Gas tokens tests', () => {
     upgrades.silenceWarnings();

--- a/test/contractsv2/BridgeL2SovereignChain.test.ts
+++ b/test/contractsv2/BridgeL2SovereignChain.test.ts
@@ -6,23 +6,10 @@ import { ethers, upgrades } from 'hardhat';
 import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { ERC20PermitMock, AgglayerGERL2, AgglayerBridgeL2, TokenWrapped } from '../../typechain-types';
 import { computeWrappedTokenProxyAddress, claimBeforeBridge } from './helpers/helpers-sovereign-bridge';
-import { valueToStorageBytes } from '../../src/utils';
+import { calculateGlobalExitRoot, valueToStorageBytes, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 function newHashChainValue(prevHashChainValue: any, valueToAdd: any) {
     return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [prevHashChainValue, valueToAdd]);

--- a/test/contractsv2/BridgeL2SovereignChainUpgradeAL.test.ts
+++ b/test/contractsv2/BridgeL2SovereignChainUpgradeAL.test.ts
@@ -9,22 +9,10 @@ import {
     TokenWrapped,
 } from '../../typechain-types';
 import { claimBeforeBridge, computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 describe('AgglayerBridgeL2 Contract Upgrade AL', () => {
     upgrades.silenceWarnings();

--- a/test/contractsv2/BridgeV2.test.ts
+++ b/test/contractsv2/BridgeV2.test.ts
@@ -3,22 +3,10 @@ import { ethers, upgrades } from 'hardhat';
 import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
 import { ERC20PermitMock, PolygonZkEVMGlobalExitRoot, AgglayerBridge, TokenWrapped } from '../../typechain-types';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 describe('PolygonZkEVMBridge Contract', () => {
     upgrades.silenceWarnings();

--- a/test/contractsv2/BridgeV2ClaimMessageReentrancy.test.ts
+++ b/test/contractsv2/BridgeV2ClaimMessageReentrancy.test.ts
@@ -2,22 +2,10 @@ import { expect } from 'chai';
 import { ethers, upgrades } from 'hardhat';
 import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { AgglayerBridge, PolygonZkEVMGlobalExitRoot } from '../../../typechain-types';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 describe('PolygonZkEVMBridge Contract claimMessage reentrancy', () => {
     upgrades.silenceWarnings();

--- a/test/contractsv2/BridgeV2GasTokens.test.ts
+++ b/test/contractsv2/BridgeV2GasTokens.test.ts
@@ -4,22 +4,10 @@ import { setBalance } from '@nomicfoundation/hardhat-network-helpers';
 import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
 import { ERC20PermitMock, PolygonZkEVMGlobalExitRoot, AgglayerBridge, TokenWrapped } from '../../typechain-types';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 describe('PolygonZkEVMBridge Gas tokens tests', () => {
     upgrades.silenceWarnings();

--- a/test/contractsv2/BridgeV2Metadata.test.ts
+++ b/test/contractsv2/BridgeV2Metadata.test.ts
@@ -9,13 +9,10 @@ import {
     ifacePermitDAI,
     createPermitSignatureUniType,
 } from '../../src/permit-helper';
+import { calculateGlobalExitRoot } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
 
 describe('PolygonZkEVMBridge Contract', () => {
     upgrades.silenceWarnings();

--- a/test/contractsv2/PolygonGlobalExitRootV2.test.ts
+++ b/test/contractsv2/PolygonGlobalExitRootV2.test.ts
@@ -3,19 +3,10 @@ import { expect } from 'chai';
 import { ethers, upgrades } from 'hardhat';
 import { MTBridge } from '@0xpolygonhermez/zkevm-commonjs';
 import { PolygonZkEVMGlobalExitRoot, AgglayerGER } from '../../typechain-types';
+import { calculateGlobalExitRoot, calculateGlobalExitRootLeaf } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-
-function calculateGlobalExitRootLeaf(newGlobalExitRoot: any, lastBlockHash: any, timestamp: any) {
-    return ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32', 'uint64'],
-        [newGlobalExitRoot, lastBlockHash, timestamp],
-    );
-}
 describe('Polygon Global exit root v2', () => {
     let rollupManager: any;
     let bridge: any;

--- a/test/contractsv2/PolygonRollupManager.test.ts
+++ b/test/contractsv2/PolygonRollupManager.test.ts
@@ -19,6 +19,7 @@ import {
 import { computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
 import { computeRandomBytes } from '../../src/pessimistic-utils';
 import { encodeInitializeBytesLegacy } from '../../src/utils-common-aggchain';
+import { calculateGlobalExitRoot, calculateGlobalExitRootLeaf, calculateAccInputHashetrog } from '../../src/utils';
 import {
     DEFAULT_ADMIN_ROLE,
     ADD_ROLLUP_TYPE_ROLE,
@@ -39,42 +40,6 @@ type BatchDataStructEtrog = PolygonRollupBaseEtrog.BatchDataStruct;
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-
-/**
- * Compute accumulateInputHash = Keccak256(oldAccInputHash, batchHashData, l1InfoTreeRoot, timestamp, seqAddress)
- * @param {String} oldAccInputHash - old accumulateInputHash
- * @param {String} batchHashData - Batch hash data
- * @param {String} globalExitRoot - Global Exit Root
- * @param {Number} timestamp - Block timestamp
- * @param {String} sequencerAddress - Sequencer address
- * @returns {String} - accumulateInputHash in hex encoding
- */
-function calculateAccInputHashetrog(
-    oldAccInputHash: any,
-    batchHashData: any,
-    l1InfoTreeRoot: any,
-    timestamp: any,
-    sequencerAddress: any,
-    forcedBlockHash: any,
-) {
-    const hashKeccak = ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32', 'bytes32', 'uint64', 'address', 'bytes32'],
-        [oldAccInputHash, batchHashData, l1InfoTreeRoot, timestamp, sequencerAddress, forcedBlockHash],
-    );
-
-    return hashKeccak;
-}
-
-function calculateGlobalExitRootLeaf(newGlobalExitRoot: any, lastBlockHash: any, timestamp: any) {
-    return ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32', 'uint64'],
-        [newGlobalExitRoot, lastBlockHash, timestamp],
-    );
-}
 
 describe('Polygon Rollup Manager', () => {
     let deployer: any;

--- a/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
+++ b/test/contractsv2/PolygonRollupManagerUpgrade.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../typechain-types';
 import { computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
 import { encodeInitializeBytesLegacy } from '../../src/utils-common-aggchain';
+import { calculateGlobalExitRoot, calculateAccInputHashetrog, computeGlobalIndex } from '../../src/utils';
 import {
     DEFAULT_ADMIN_ROLE,
     ADD_ROLLUP_TYPE_ROLE,
@@ -40,44 +41,6 @@ type BatchDataStructEtrog = PolygonRollupBaseEtrog.BatchDataStruct;
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
-
-/**
- * Compute accumulateInputHash = Keccak256(oldAccInputHash, batchHashData, globalExitRoot, timestamp, seqAddress)
- * @param {String} oldAccInputHash - old accumulateInputHash
- * @param {String} batchHashData - Batch hash data
- * @param {String} globalExitRoot - Global Exit Root
- * @param {Number} timestamp - Block timestamp
- * @param {String} sequencerAddress - Sequencer address
- * @returns {String} - accumulateInputHash in hex encoding
- */
-function calculateAccInputHashetrog(
-    oldAccInputHash: any,
-    batchHashData: any,
-    globalExitRoot: any,
-    timestamp: any,
-    sequencerAddress: any,
-    forcedBlockHash: any,
-) {
-    const hashKeccak = ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32', 'bytes32', 'uint64', 'address', 'bytes32'],
-        [oldAccInputHash, batchHashData, globalExitRoot, timestamp, sequencerAddress, forcedBlockHash],
-    );
-
-    return hashKeccak;
-}
 
 const SIGNATURE_BYTES = 32 + 32 + 1;
 const EFFECTIVE_PERCENTAGE_BYTES = 1;

--- a/test/contractsv2/PolygonValidiumEtrog.test.ts
+++ b/test/contractsv2/PolygonValidiumEtrog.test.ts
@@ -15,41 +15,13 @@ import {
     PolygonDataCommittee,
 } from '../../typechain-types';
 import { computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
+import { calculateGlobalExitRoot, calculateAccInputHashetrog } from '../../src/utils';
 
 type BatchDataStructEtrog = PolygonRollupBaseEtrog.BatchDataStruct;
 type ValidiumBatchData = PolygonValidiumEtrog.ValidiumBatchDataStruct;
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-
-/**
- * Compute accumulateInputHash = Keccak256(oldAccInputHash, batchHashData, globalExitRoot, timestamp, seqAddress)
- * @param {String} oldAccInputHash - old accumulateInputHash
- * @param {String} batchHashData - Batch hash data
- * @param {String} globalExitRoot - Global Exit Root
- * @param {Number} timestamp - Block timestamp
- * @param {String} sequencerAddress - Sequencer address
- * @returns {String} - accumulateInputHash in hex encoding
- */
-function calculateAccInputHashetrog(
-    oldAccInputHash: any,
-    batchHashData: any,
-    globalExitRoot: any,
-    timestamp: any,
-    sequencerAddress: any,
-    forcedBlockHash: any,
-) {
-    const hashKeccak = ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32', 'bytes32', 'uint64', 'address', 'bytes32'],
-        [oldAccInputHash, batchHashData, globalExitRoot, timestamp, sequencerAddress, forcedBlockHash],
-    );
-
-    return hashKeccak;
-}
 
 describe('PolygonValidiumEtrog', () => {
     let deployer: any;

--- a/test/contractsv2/PolygonZkEVMEtrog.test.ts
+++ b/test/contractsv2/PolygonZkEVMEtrog.test.ts
@@ -14,40 +14,12 @@ import {
     Address,
 } from '../../typechain-types';
 import { computeWrappedTokenProxyAddress } from './helpers/helpers-sovereign-bridge';
+import { calculateGlobalExitRoot, calculateAccInputHashetrog } from '../../src/utils';
 
 type BatchDataStructEtrog = PolygonRollupBaseEtrog.BatchDataStruct;
 
 const MerkleTreeBridge = MTBridge;
 const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-
-/**
- * Compute accumulateInputHash = Keccak256(oldAccInputHash, batchHashData, globalExitRoot, timestamp, seqAddress)
- * @param {String} oldAccInputHash - old accumulateInputHash
- * @param {String} batchHashData - Batch hash data
- * @param {String} globalExitRoot - Global Exit Root
- * @param {Number} timestamp - Block timestamp
- * @param {String} sequencerAddress - Sequencer address
- * @returns {String} - accumulateInputHash in hex encoding
- */
-function calculateAccInputHashetrog(
-    oldAccInputHash: any,
-    batchHashData: any,
-    globalExitRoot: any,
-    timestamp: any,
-    sequencerAddress: any,
-    forcedBlockHash: any,
-) {
-    const hashKeccak = ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32', 'bytes32', 'uint64', 'address', 'bytes32'],
-        [oldAccInputHash, batchHashData, globalExitRoot, timestamp, sequencerAddress, forcedBlockHash],
-    );
-
-    return hashKeccak;
-}
 
 describe('PolygonZkEVMEtrog', () => {
     let deployer: any;

--- a/test/contractsv2/UpgradeToPP.test.ts
+++ b/test/contractsv2/UpgradeToPP.test.ts
@@ -18,6 +18,7 @@ import {
 import { encodeInitializeBytesLegacy } from '../../src/utils-common-aggchain';
 import { VerifierType, computeRandomBytes } from '../../src/pessimistic-utils';
 import { AL_MULTISIG_ROLE } from '../../src/constants';
+import { calculateGlobalExitRoot, calculateGlobalExitRootLeaf, calculateAccInputHashetrog } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { getLeafValue } = mtBridgeUtils;
@@ -359,7 +360,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
             forcedBlockHashL1: ethers.ZeroHash,
         } as PolygonValidiumEtrog.ValidiumBatchDataStruct;
 
-        const expectedAccInputHash = calculateAccInputHashEtrog(
+        const expectedAccInputHash = calculateAccInputHashetrog(
             await validiumContract.lastAccInputHash(),
             hashedData,
             await polygonZkEVMGlobalExitRoot.getRoot(),
@@ -616,7 +617,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
             forcedBlockHashL1: ethers.ZeroHash,
         } as PolygonValidiumEtrog.ValidiumBatchDataStruct;
 
-        const expectedAccInputHash = calculateAccInputHashEtrog(
+        const expectedAccInputHash = calculateAccInputHashetrog(
             await validiumContract.lastAccInputHash(),
             hashedData,
             await polygonZkEVMGlobalExitRoot.getRoot(),
@@ -905,7 +906,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
             '0x', // empty metadata
         );
 
-        const expectedAccInputHash = calculateAccInputHashEtrog(
+        const expectedAccInputHash = calculateAccInputHashetrog(
             ethers.ZeroHash,
             ethers.keccak256(transaction),
             await polygonZkEVMGlobalExitRoot.getLastGlobalExitRoot(),
@@ -951,7 +952,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
 
         const rootSC = await polygonZkEVMGlobalExitRoot.getRoot();
 
-        const expectedAccInputHash2 = calculateAccInputHashEtrog(
+        const expectedAccInputHash2 = calculateAccInputHashetrog(
             expectedAccInputHash,
             ethers.keccak256(l2txData),
             rootSC,
@@ -1226,7 +1227,7 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
             forcedBlockHashL1: ethers.ZeroHash,
         } as PolygonValidiumEtrog.ValidiumBatchDataStruct;
 
-        const expectedAccInputHash = calculateAccInputHashEtrog(
+        const expectedAccInputHash = calculateAccInputHashetrog(
             await validiumContract.lastAccInputHash(),
             hashedData,
             await polygonZkEVMGlobalExitRoot.getRoot(),
@@ -1384,40 +1385,4 @@ describe('Upgradeable to PPV2 or ALGateway', () => {
 
         expect(await rollupManagerContract.isRollupMigrating(newCreatedRollupID)).to.be.equal(false);
     });
-
-    /**
-     * Compute accumulateInputHash = Keccak256(oldAccInputHash, batchHashData, l1InfoTreeRoot, timestamp, seqAddress)
-     * @param {String} oldAccInputHash - old accumulateInputHash
-     * @param {String} batchHashData - Batch hash data
-     * @param {String} globalExitRoot - Global Exit Root
-     * @param {Number} timestamp - Block timestamp
-     * @param {String} sequencerAddress - Sequencer address
-     * @returns {String} - accumulateInputHash in hex encoding
-     */
-    function calculateAccInputHashEtrog(
-        oldAccInputHash: any,
-        batchHashData: any,
-        l1InfoTreeRoot: any,
-        timestamp: any,
-        sequencerAddress: any,
-        forcedBlockHash: any,
-    ) {
-        const hashKeccak = ethers.solidityPackedKeccak256(
-            ['bytes32', 'bytes32', 'bytes32', 'uint64', 'address', 'bytes32'],
-            [oldAccInputHash, batchHashData, l1InfoTreeRoot, timestamp, sequencerAddress, forcedBlockHash],
-        );
-
-        return hashKeccak;
-    }
-
-    function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-        return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-    }
-
-    function calculateGlobalExitRootLeaf(newGlobalExitRoot: any, lastBlockHash: any, timestamp: any) {
-        return ethers.solidityPackedKeccak256(
-            ['bytes32', 'bytes32', 'uint64'],
-            [newGlobalExitRoot, lastBlockHash, timestamp],
-        );
-    }
 });

--- a/test/contractsv2/claimCompressor/ClaimCompressor.test.ts
+++ b/test/contractsv2/claimCompressor/ClaimCompressor.test.ts
@@ -4,6 +4,7 @@ import { ethers, upgrades } from 'hardhat';
 import { takeSnapshot } from '@nomicfoundation/hardhat-network-helpers';
 import { processorUtils, MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { PolygonZkEVMGlobalExitRoot, AgglayerBridge, ClaimCompressor, BridgeReceiverMock } from '../../typechain-types';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../src/utils';
 
 const MerkleTreeBridge = MTBridge;
 const { getLeafValue } = mtBridgeUtils;
@@ -21,19 +22,6 @@ function calculateCallDataCost(calldataBytes: string): number {
     }
 
     return totalCost;
-}
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
 }
 
 describe('Claim Compressor Contract', () => {

--- a/test/contractsv2/helpers/helpers-sovereign-bridge.ts
+++ b/test/contractsv2/helpers/helpers-sovereign-bridge.ts
@@ -1,23 +1,9 @@
 import { ethers } from 'hardhat';
 import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
+import { calculateGlobalExitRoot, computeGlobalIndex } from '../../../src/utils';
 
 const { getLeafValue } = mtBridgeUtils;
 const MerkleTreeBridge = MTBridge;
-
-// Constants
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
-
-export function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
-
-export function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
 
 export async function computeWrappedTokenProxyAddress(
     networkId: any,

--- a/tools/deploySovereignTest/deploySovereign.ts
+++ b/tools/deploySovereignTest/deploySovereign.ts
@@ -7,6 +7,7 @@ import * as dotenv from 'dotenv';
 import { ethers, upgrades } from 'hardhat';
 import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
 import { AgglayerGERL2, AgglayerBridgeL2 } from '../../typechain-types';
+import { calculateGlobalExitRoot, calculateGlobalExitRootLeaf, computeGlobalIndex } from '../../src/utils';
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 const MerkleTreeBridge = MTBridge;
@@ -14,28 +15,8 @@ const { getLeafValue } = mtBridgeUtils;
 
 const pathOutput = path.join(__dirname, `./output__${new Date().toISOString()}.json`);
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
 const rollupID = 0;
 const networkIDMainnet = 0;
-
-function calculateGlobalExitRootLeaf(newGlobalExitRoot: any, lastBlockHash: any, timestamp: any) {
-    return ethers.solidityPackedKeccak256(
-        ['bytes32', 'bytes32', 'uint64'],
-        [newGlobalExitRoot, lastBlockHash, timestamp],
-    );
-}
-
-function calculateGlobalExitRoot(mainnetExitRoot: any, rollupExitRoot: any) {
-    return ethers.solidityPackedKeccak256(['bytes32', 'bytes32'], [mainnetExitRoot, rollupExitRoot]);
-}
-
-function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
-    if (isMainnet === true) {
-        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
-    }
-    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
-}
 
 function simulateGERWithEtherClaims(destinationAddress: any) {
     const LEAF_TYPE_ASSET = 0;


### PR DESCRIPTION
* This PR simply moves duplicated code into utils.
* The following functions were duplicated all over the place `calculateGlobalExitRoot`, `calculateGlobalExitRootLeaf`, `calculateAccInputHashetrog`, `computeGlobalIndex`.
* This PR moves them to utils so that they are referenced from a single place.




