### PR TITLE
Fix typo: MENMONIC -> MNEMONIC in docker/README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ By default the following mnemonic will be used to deploy the smart contracts `MN
 Also the first 20 accounts of this mnemonic will be funded with ether.
 The first account of the mnemonic will be the deployer of the smart contracts and therefore the holder of all the MATIC test tokens, which are necessary to pay the `sendBatch` transactions.
 You can change the deployment `mnemonic` creating a `.env` file in the project root with the following variable:
-`MNEMONIC=<YOUR_MENMONIC>`
+`MNEMONIC=<YOUR_MNEMONIC>`
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Fixed typo in docker/README.md where "MENMONIC" was misspelled instead of "MNEMONIC"

## Test plan
- Visual inspection of the documentation change