### PR TITLE
Fix typo: remove duplicate word in PolygonRollupManager comment

### DIFF
--- a/contracts/v2/PolygonRollupManager.sol
+++ b/contracts/v2/PolygonRollupManager.sol
@@ -336,7 +336,7 @@ contract PolygonRollupManager is
     );
 
     /**
-     * @dev Emitted when a a rollup type is obsoleted
+     * @dev Emitted when a rollup type is obsoleted
      */
     event ObsoleteRollupType(uint32 indexed rollupTypeID);
 


### PR DESCRIPTION
## Summary
- Fixed duplicate word "a a" -> "a" in NatSpec comment for ObsoleteRollupType event in contracts/v2/PolygonRollupManager.sol

## Test plan
- Visual inspection of the comment change