### PR TITLE
Fix typo: especial -> special in PolygonZkEVMExistentEtrog comment

### DIFF
--- a/contracts/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.sol
+++ b/contracts/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.sol
@@ -66,7 +66,7 @@ contract PolygonZkEVMExistentEtrog is PolygonRollupBaseEtrog {
 
     /**
      * note This initializer will be called instead of the PolygonRollupBase
-     * This is a especial initializer since the zkEVM it's an already created network
+     * This is a special initializer since the zkEVM is an already created network
      * @param _admin Admin address
      * @param _trustedSequencer Trusted sequencer address
      * @param _trustedSequencerURL Trusted sequencer URL


### PR DESCRIPTION
## Summary
- Fixed typo in contracts/v2/consensus/zkEVM/PolygonZkEVMExistentEtrog.sol:
  - "especial" -> "special"
  - "it's an already" -> "is an already" (grammar improvement)

## Test plan
- Visual inspection of the comment change