### PR TITLE
Fix typo: btyecode -> bytecode in verifyMainnetDeployment.js

### DIFF
--- a/verifyMainnetDeployment/verifyMainnetDeployment.js
+++ b/verifyMainnetDeployment/verifyMainnetDeployment.js
@@ -65,7 +65,7 @@ async function main() {
     console.log('Path file: ', path.join(__dirname, pathTransparentProxy));
     console.log();
 
-    // The other 3 contracts are immutables, therefore we will deploy them locally and check the btyecode against the deployed one
+    // The other 3 contracts are immutables, therefore we will deploy them locally and check the bytecode against the deployed one
 
     // PolygonZkEVMTimelock
     const PolygonZkEVMTimelockFactory = await ethers.getContractFactory('PolygonZkEVMTimelock');


### PR DESCRIPTION
## Summary
- Fixed typo in verifyMainnetDeployment/verifyMainnetDeployment.js:
  - "btyecode" -> "bytecode" in comment

## Test plan
- Visual inspection of the comment change