### PR TITLE
update hardhat-verify & enable sourcify

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -354,6 +354,10 @@ const config: HardhatUserConfig = {
         outputFile: process.env.REPORT_GAS_FILE ? './gas_report.md' : undefined,
         noColors: !!process.env.REPORT_GAS_FILE,
     },
+    sourcify: {
+        // Doesn't need an API key
+        enabled: true,
+    },
     etherscan: {
         apiKey: {
             polygonZKEVMTestnet: `${process.env.ETHERSCAN_ZKEVM_API_KEY}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
                 "@nomicfoundation/hardhat-ledger": "^1.2.2",
                 "@nomicfoundation/hardhat-network-helpers": "^1.0.12",
-                "@nomicfoundation/hardhat-verify": "^1.1.1",
+                "@nomicfoundation/hardhat-verify": "^2.1.3",
                 "@nomiclabs/hardhat-solhint": "^4.0.1",
                 "@openzeppelin/contracts-upgradeable4": "npm:@openzeppelin/contracts-upgradeable@4.8.2",
                 "@openzeppelin/contracts-upgradeable5": "npm:@openzeppelin/contracts-upgradeable@5.0.0",
@@ -2803,35 +2803,24 @@
             }
         },
         "node_modules/@nomicfoundation/hardhat-verify": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.1.1.tgz",
-            "integrity": "sha512-9QsTYD7pcZaQFEA3tBb/D/oCStYDiEVDN7Dxeo/4SCyHRSm86APypxxdOMEPlGmXsAvd+p1j/dTODcpxb8aztA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.1.3.tgz",
+            "integrity": "sha512-danbGjPp2WBhLkJdQy9/ARM3WQIK+7vwzE0urNem1qZJjh9f54Kf5f1xuQv8DvqewUAkuPxVt/7q4Grz5WjqSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@ethersproject/abi": "^5.1.2",
                 "@ethersproject/address": "^5.0.2",
                 "cbor": "^8.1.0",
-                "chalk": "^2.4.2",
                 "debug": "^4.1.1",
                 "lodash.clonedeep": "^4.5.0",
+                "picocolors": "^1.1.0",
                 "semver": "^6.3.0",
                 "table": "^6.8.0",
                 "undici": "^5.14.0"
             },
             "peerDependencies": {
-                "hardhat": "^2.0.4"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-verify/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
+                "hardhat": "^2.26.0"
             }
         },
         "node_modules/@nomicfoundation/hardhat-verify/node_modules/cbor": {
@@ -2844,65 +2833,6 @@
             },
             "engines": {
                 "node": ">=12.19"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-verify/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-verify/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-verify/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
-        },
-        "node_modules/@nomicfoundation/hardhat-verify/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-verify/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@nomicfoundation/hardhat-verify/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@nomicfoundation/slang": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
         "@nomicfoundation/hardhat-ledger": "^1.2.2",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.12",
-        "@nomicfoundation/hardhat-verify": "^1.1.1",
+        "@nomicfoundation/hardhat-verify": "^2.1.3",
         "@nomiclabs/hardhat-solhint": "^4.0.1",
         "@openzeppelin/contracts-upgradeable4": "npm:@openzeppelin/contracts-upgradeable@4.8.2",
         "@openzeppelin/contracts-upgradeable5": "npm:@openzeppelin/contracts-upgradeable@5.0.0",
@@ -69,6 +69,11 @@
         "ts-node": "^10.9.2",
         "typechain": "^8.3.2",
         "winston": "^3.17.0"
+    },
+    "overrides": {
+        "@openzeppelin/hardhat-upgrades": {
+            "@nomicfoundation/hardhat-verify": "$@nomicfoundation/hardhat-verify"
+        }
     },
     "scripts": {
         "saveDeployment:mainnet": "mkdir -p deployments/mainnet_$(date +%s) && cp -r deployment/v2/deploy_*.json deployments/mainnet_$(date +%s) && cp .openzeppelin/mainnet.json deployments/mainnet_$(date +%s) && cp deployment/v2/genesis.json deployments/mainnet_$(date +%s) && cp deployment/v2/create_rollup_output_*.json deployments/mainnet_$(date +%s)",

--- a/tools/getLBT/.gitignore
+++ b/tools/getLBT/.gitignore
@@ -1,3 +1,4 @@
 parameters.json
 WTokens*
 LBT*
+events.json


### PR DESCRIPTION
This PR does the following:
- bump `hardhat-verify` version to `2.1.3` to enable push to `sourcify` automatically