### PR TITLE
Fix inconsistency: updating lastUpdatedDepositCount on backwardLET & …

### DIFF
--- a/contracts/sovereignChains/AgglayerBridgeL2.sol
+++ b/contracts/sovereignChains/AgglayerBridgeL2.sol
@@ -774,8 +774,9 @@ contract AgglayerBridgeL2 is AgglayerBridge, IAgglayerBridgeL2 {
 
         depositCount = newDepositCount;
 
-        // Update LER
+        // Update LER & lastUpdatedDepositCount
         bytes32 newLER = getRoot();
+        lastUpdatedDepositCount = uint32(newDepositCount);
         globalExitRootManager.updateExitRoot(newLER);
 
         // emit event
@@ -837,7 +838,8 @@ contract AgglayerBridgeL2 is AgglayerBridge, IAgglayerBridgeL2 {
             revert InvalidExpectedLER();
         }
 
-        // Update GER
+        // Update LER & lastUpdatedDepositCount
+        lastUpdatedDepositCount = uint32(depositCount);
         globalExitRootManager.updateExitRoot(computedRoot);
 
         // emit event with the new deposit count

--- a/test/contractsv2/BridgeL2SovereignChain.test.ts
+++ b/test/contractsv2/BridgeL2SovereignChain.test.ts
@@ -3435,6 +3435,57 @@ describe('AgglayerBridgeL2 Contract', () => {
                 // Verify the root changed (different from original)
                 expect(await sovereignChainBridgeContract.getRoot()).to.not.equal(originalTree.getRoot());
             });
+
+            it('should update lastUpdatedDepositCount after backwardLET', async () => {
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
+                const originalLeaves = generateTestLeaves(3);
+                const originalTree = buildMerkleTreeForTesting(originalLeaves);
+                await sovereignChainBridgeContract
+                    .connect(globalExitRootRemover)
+                    .forwardLET(originalLeaves, originalTree.getRoot());
+
+                expect(await sovereignChainBridgeContract.depositCount()).to.equal(3);
+
+                // Deactivate emergency, sync lastUpdatedDepositCount via updateGlobalExitRoot, re-activate
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).deactivateEmergencyState();
+                await sovereignChainBridgeContract.updateGlobalExitRoot();
+                expect(await sovereignChainBridgeContract.lastUpdatedDepositCount()).to.equal(3);
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
+                // Rollback to 1 leaf
+                const newDepositCount = 1;
+
+                const newFrontier = Array(32).fill(ethers.ZeroHash);
+                newFrontier[0] = getLeafValue(
+                    originalLeaves[0].leafType,
+                    originalLeaves[0].originNetwork,
+                    originalLeaves[0].originAddress,
+                    originalLeaves[0].destinationNetwork,
+                    originalLeaves[0].destinationAddress,
+                    originalLeaves[0].amount,
+                    ethers.keccak256(originalLeaves[0].metadata),
+                );
+
+                const nextLeaf = originalLeaves[newDepositCount];
+                const nextLeafValue = getLeafValue(
+                    nextLeaf.leafType,
+                    nextLeaf.originNetwork,
+                    nextLeaf.originAddress,
+                    nextLeaf.destinationNetwork,
+                    nextLeaf.destinationAddress,
+                    nextLeaf.amount,
+                    ethers.keccak256(nextLeaf.metadata),
+                );
+                const proof = originalTree.getProofTreeByIndex(newDepositCount);
+
+                await sovereignChainBridgeContract
+                    .connect(globalExitRootRemover)
+                    .backwardLET(newDepositCount, newFrontier as [string, ...string[]], nextLeafValue, proof);
+
+                expect(await sovereignChainBridgeContract.depositCount()).to.equal(1);
+                expect(await sovereignChainBridgeContract.lastUpdatedDepositCount()).to.equal(1);
+            });
         });
 
         describe('forwardLET', () => {
@@ -3744,6 +3795,22 @@ describe('AgglayerBridgeL2 Contract', () => {
 
                 // Verify no leaves were added (transaction reverted)
                 expect(await sovereignChainBridgeContract.depositCount()).to.equal(0);
+            });
+
+            it('should update lastUpdatedDepositCount after forwardLET', async () => {
+                await sovereignChainBridgeContract.connect(emergencyBridgePauser).activateEmergencyState();
+
+                expect(await sovereignChainBridgeContract.lastUpdatedDepositCount()).to.equal(0);
+                expect(await sovereignChainBridgeContract.depositCount()).to.equal(0);
+
+                const newLeaves = generateTestLeaves(3);
+                const expectedTree = buildMerkleTreeForTesting(newLeaves);
+                await sovereignChainBridgeContract
+                    .connect(globalExitRootRemover)
+                    .forwardLET(newLeaves, expectedTree.getRoot());
+
+                expect(await sovereignChainBridgeContract.depositCount()).to.equal(3);
+                expect(await sovereignChainBridgeContract.lastUpdatedDepositCount()).to.equal(3);
             });
         });
 


### PR DESCRIPTION
## Description
This pull request updates the `AgglayerBridgeL2` contract to ensure that the `lastUpdatedDepositCount` variable is correctly updated during both forward and backward LET (Leaf Event Tree) operations.

## Details
**Contract logic improvements:**

* Updated the `AgglayerBridgeL2.sol` contract to set `lastUpdatedDepositCount` whenever the LER (Local Exit Root) is updated in both `forwardLET` and `backwardLET` operations, ensuring consistency between the deposit count and the last updated state. [[1]](diffhunk://#diff-2f8130909dabb2383aed221053adf0b096183239846b2f3d84c66516c5d857b1L777-R779) [[2]](diffhunk://#diff-2f8130909dabb2383aed221053adf0b096183239846b2f3d84c66516c5d857b1L840-R842)

**Testing enhancements:**

* Added a test to verify that `lastUpdatedDepositCount` is updated correctly after a `forwardLET` operation, especially in emergency state scenarios.
* Added a test to verify that `lastUpdatedDepositCount` is updated correctly after a `backwardLET` operation, including scenarios where the deposit count is rolled back.