### PR TITLE
feat: add ERC-7786 gateway adapter for AgglayerBridge

### DIFF
--- a/contracts/mocks/ERC7786RecipientMock.sol
+++ b/contracts/mocks/ERC7786RecipientMock.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity 0.8.28;
+
+import {IERC7786Recipient} from "../periphery/erc7786/IERC7786.sol";
+
+/**
+ * @title ERC7786RecipientMock
+ * @author Polygon Technology
+ * @notice Mock ERC-7786 recipient that records received messages, used to test
+ * the AgglayerERC7786Gateway delivery path
+ */
+contract ERC7786RecipientMock is IERC7786Recipient {
+    /// @notice Receive id of the last received message
+    bytes32 public lastReceiveId;
+
+    /// @notice ERC-7930 sender of the last received message
+    bytes public lastSender;
+
+    /// @notice Payload of the last received message
+    bytes public lastPayload;
+
+    /// @notice Native value received with the last message
+    uint256 public lastValue;
+
+    /// @notice Caller (gateway) of the last received message
+    address public lastCaller;
+
+    /// @notice Number of messages received
+    uint256 public receivedCount;
+
+    /// @notice If true, receiveMessage returns a wrong selector
+    bool public returnInvalidSelector;
+
+    /**
+     * @notice Configures whether receiveMessage returns a wrong selector
+     * @param value True to return a wrong selector
+     */
+    function setReturnInvalidSelector(bool value) external {
+        returnInvalidSelector = value;
+    }
+
+    /**
+     * @notice Records the received message
+     * @param receiveId Unique identifier of the message being relayed
+     * @param sender Binary Interoperable Address (ERC-7930) of the sender
+     * @param payload Message payload
+     * @return The receiveMessage selector, or a wrong one if configured
+     */
+    function receiveMessage(
+        bytes32 receiveId,
+        bytes calldata sender,
+        bytes calldata payload
+    ) external payable returns (bytes4) {
+        lastReceiveId = receiveId;
+        lastSender = sender;
+        lastPayload = payload;
+        lastValue = msg.value;
+        lastCaller = msg.sender;
+        ++receivedCount;
+
+        if (returnInvalidSelector) {
+            return 0xffffffff;
+        }
+        return IERC7786Recipient.receiveMessage.selector;
+    }
+}

--- a/contracts/periphery/erc7786/AgglayerERC7786Gateway.sol
+++ b/contracts/periphery/erc7786/AgglayerERC7786Gateway.sol
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity 0.8.28;
+
+import {Ownable} from "@openzeppelin/contracts5/access/Ownable.sol";
+import {IBridgeMessageReceiver} from "../../interfaces/IBridgeMessageReceiver.sol";
+import {IERC7786GatewaySource, IERC7786Recipient} from "./IERC7786.sol";
+import {InteroperableAddress} from "./InteroperableAddress.sol";
+
+/**
+ * @dev Minimal interface of the AgglayerBridge required by the gateway
+ */
+interface IAgglayerBridgeMessenger {
+    function bridgeMessage(
+        uint32 destinationNetwork,
+        address destinationAddress,
+        bool forceUpdateGlobalExitRoot,
+        bytes calldata metadata
+    ) external payable;
+
+    function networkID() external view returns (uint32);
+}
+
+/**
+ * @title AgglayerERC7786Gateway
+ * @notice ERC-7786 gateway adapter on top of the AgglayerBridge message-passing layer.
+ * See https://eips.ethereum.org/EIPS/eip-7786
+ *
+ * Acts as a source gateway: `sendMessage` wraps the message into the AgglayerBridge
+ * `bridgeMessage` flow, targeting the trusted counterpart gateway on the destination
+ * network. Acts as a destination gateway: `onMessageReceived` (invoked by the bridge
+ * on claim) validates the origin and forwards the message to the final
+ * `IERC7786Recipient`.
+ *
+ * ERC-7930 interoperable addresses use eip155 (EVM) chain ids. The owner registers
+ * each remote network with a single call to `registerRemoteNetwork`, which maps the
+ * chain id to the Agglayer network id and sets the trusted counterpart gateway
+ * deployed on that network.
+ */
+contract AgglayerERC7786Gateway is
+    IERC7786GatewaySource,
+    IBridgeMessageReceiver,
+    Ownable
+{
+    using InteroperableAddress for bytes;
+
+    /**
+     * @dev Attribute key for `forceUpdateGlobalExitRoot(bool)`, forwarded to
+     * the bridge to force an update of the global exit root when bridging
+     */
+    bytes4 public constant FORCE_UPDATE_GLOBAL_EXIT_ROOT_ATTRIBUTE =
+        bytes4(keccak256("forceUpdateGlobalExitRoot(bool)"));
+
+    /// @notice AgglayerBridge this gateway wraps
+    IAgglayerBridgeMessenger public immutable bridge;
+
+    /// @notice Agglayer network id of the network this gateway is deployed on
+    uint32 public immutable localNetworkID;
+
+    /// @notice EIP-155 chain id -> Agglayer network id (+1, 0 means unregistered)
+    mapping(uint256 chainId => uint256 networkIdPlusOne)
+        internal _chainIdToNetworkID;
+
+    /// @notice Agglayer network id -> EIP-155 chain id (0 means unregistered)
+    mapping(uint32 networkID => uint256 chainId) public networkIDToChainId;
+
+    /// @notice Agglayer network id -> trusted counterpart gateway on that network
+    mapping(uint32 networkID => address gateway) public remoteGateways;
+
+    /// @notice Counter used to generate unique send identifiers
+    uint256 public nonce;
+
+    /**
+     * @dev Emitted when a remote network (chainId <-> networkID pair and its
+     * counterpart gateway) is registered
+     */
+    event RemoteNetworkRegistered(
+        uint256 chainId,
+        uint32 networkID,
+        address gateway
+    );
+
+    /**
+     * @dev Thrown when the destination chain id is not mapped to an Agglayer network id
+     */
+    error UnregisteredChain(uint256 chainId);
+
+    /**
+     * @dev Thrown when registering a remote network with empty values
+     */
+    error InvalidZeroValue();
+
+    /**
+     * @dev Thrown when `onMessageReceived` is not called by the bridge
+     */
+    error OnlyBridge();
+
+    /**
+     * @dev Thrown when the origin of a received message is not the trusted
+     * counterpart gateway of the origin network
+     */
+    error UntrustedOriginGateway(uint32 originNetwork, address originAddress);
+
+    /**
+     * @dev Thrown when the recipient does not return the expected
+     * `IERC7786Recipient.receiveMessage` selector
+     */
+    error InvalidRecipientReturnValue();
+
+    /**
+     * @param _bridge AgglayerBridge address
+     * @param _initialOwner Owner allowed to register chains and remote gateways
+     */
+    constructor(
+        IAgglayerBridgeMessenger _bridge,
+        address _initialOwner
+    ) Ownable(_initialOwner) {
+        bridge = _bridge;
+        localNetworkID = _bridge.networkID();
+    }
+
+    ////////////////////////////
+    // Owner configuration
+    ////////////////////////////
+
+    /**
+     * @notice Registers a remote network: maps its EIP-155 chain id to its Agglayer
+     * network id (bidirectionally) and sets the trusted counterpart gateway deployed
+     * on that network
+     * @param chainId EIP-155 chain id of the remote network (must be non-zero)
+     * @param networkID Agglayer network id of the remote network
+     * @param gateway Counterpart gateway address on that network (must be non-zero)
+     */
+    function registerRemoteNetwork(
+        uint256 chainId,
+        uint32 networkID,
+        address gateway
+    ) external onlyOwner {
+        if (chainId == 0 || gateway == address(0)) {
+            revert InvalidZeroValue();
+        }
+        _chainIdToNetworkID[chainId] = uint256(networkID) + 1;
+        networkIDToChainId[networkID] = chainId;
+        remoteGateways[networkID] = gateway;
+
+        emit RemoteNetworkRegistered(chainId, networkID, gateway);
+    }
+
+    ////////////////////////////
+    // ERC-7786 source gateway
+    ////////////////////////////
+
+    /**
+     * @inheritdoc IERC7786GatewaySource
+     */
+    function supportsAttribute(bytes4 selector) external pure returns (bool) {
+        return selector == FORCE_UPDATE_GLOBAL_EXIT_ROOT_ATTRIBUTE;
+    }
+
+    /**
+     * @inheritdoc IERC7786GatewaySource
+     * @dev The recipient must be an ERC-7930 v1 eip155 address on a chain registered
+     * via `registerRemoteNetwork`. Any native value is forwarded through the bridge
+     * and delivered to the recipient on claim (only on ether gas token networks).
+     */
+    function sendMessage(
+        bytes calldata recipient,
+        bytes calldata payload,
+        bytes[] calldata attributes
+    ) external payable returns (bytes32 sendId) {
+        sendId = keccak256(abi.encode(block.chainid, address(this), nonce++));
+
+        _dispatchMessage(sendId, recipient, payload, attributes);
+
+        emit MessageSent(
+            sendId,
+            InteroperableAddress.formatEvmV1(block.chainid, msg.sender),
+            recipient,
+            payload,
+            msg.value,
+            attributes
+        );
+    }
+
+    /**
+     * @dev Resolves the destination and bridges the message through the AgglayerBridge
+     */
+    function _dispatchMessage(
+        bytes32 sendId,
+        bytes calldata recipient,
+        bytes calldata payload,
+        bytes[] calldata attributes
+    ) internal {
+        (uint256 destinationChainId, address recipientAddress) = recipient
+            .parseEvmV1();
+
+        // Both mappings are set atomically in registerRemoteNetwork, so a
+        // registered chain id always has a non-zero counterpart gateway
+        uint32 destinationNetwork = chainIdToNetworkID(destinationChainId);
+        address remoteGateway = remoteGateways[destinationNetwork];
+
+        bytes memory metadata = abi.encode(
+            sendId,
+            msg.sender,
+            recipientAddress,
+            payload
+        );
+
+        bridge.bridgeMessage{value: msg.value}(
+            destinationNetwork,
+            remoteGateway,
+            _processAttributes(attributes),
+            metadata
+        );
+    }
+
+    ////////////////////////////
+    // Destination gateway
+    ////////////////////////////
+
+    /**
+     * @notice Entry point called by the AgglayerBridge when a message targeting this
+     * gateway is claimed. Validates the origin and delivers the message to the final
+     * ERC-7786 recipient, forwarding any native value.
+     * @param originAddress Address that called `bridgeMessage` on the origin network
+     * (must be the trusted counterpart gateway)
+     * @param originNetwork Agglayer network id of the origin network
+     * @param data Cross-chain metadata: abi.encode(sendId, sender, recipient, payload)
+     */
+    function onMessageReceived(
+        address originAddress,
+        uint32 originNetwork,
+        bytes memory data
+    ) external payable {
+        if (msg.sender != address(bridge)) {
+            revert OnlyBridge();
+        }
+        if (
+            originAddress == address(0) ||
+            originAddress != remoteGateways[originNetwork]
+        ) {
+            revert UntrustedOriginGateway(originNetwork, originAddress);
+        }
+
+        // Set atomically with remoteGateways in registerRemoteNetwork, so it is
+        // always non-zero when the origin gateway is trusted
+        uint256 originChainId = networkIDToChainId[originNetwork];
+
+        (
+            bytes32 sendId,
+            address sender,
+            address recipient,
+            bytes memory payload
+        ) = abi.decode(data, (bytes32, address, address, bytes));
+
+        bytes4 returnValue = IERC7786Recipient(recipient).receiveMessage{
+            value: msg.value
+        }(
+            sendId,
+            InteroperableAddress.formatEvmV1(originChainId, sender),
+            payload
+        );
+
+        if (returnValue != IERC7786Recipient.receiveMessage.selector) {
+            revert InvalidRecipientReturnValue();
+        }
+    }
+
+    ////////////////////////////
+    // View functions
+    ////////////////////////////
+
+    /**
+     * @notice Returns the Agglayer network id registered for an EIP-155 chain id
+     * @dev Reverts if the chain id is not registered
+     */
+    function chainIdToNetworkID(uint256 chainId) public view returns (uint32) {
+        uint256 networkIdPlusOne = _chainIdToNetworkID[chainId];
+        if (networkIdPlusOne == 0) {
+            revert UnregisteredChain(chainId);
+        }
+        return uint32(networkIdPlusOne - 1);
+    }
+
+    ////////////////////////////
+    // Internal functions
+    ////////////////////////////
+
+    /**
+     * @dev Validates the attributes list. Only `forceUpdateGlobalExitRoot(bool)`
+     * is supported; any other attribute key reverts with `UnsupportedAttribute`.
+     * If provided multiple times, the last value wins.
+     */
+    function _processAttributes(
+        bytes[] calldata attributes
+    ) internal pure returns (bool forceUpdateGlobalExitRoot) {
+        for (uint256 i = 0; i < attributes.length; i++) {
+            bytes calldata attribute = attributes[i];
+            bytes4 selector = bytes4(attribute);
+            if (
+                selector != FORCE_UPDATE_GLOBAL_EXIT_ROOT_ATTRIBUTE ||
+                attribute.length != 36
+            ) {
+                revert UnsupportedAttribute(selector);
+            }
+            forceUpdateGlobalExitRoot = abi.decode(attribute[4:], (bool));
+        }
+    }
+}

--- a/contracts/periphery/erc7786/IERC7786.sol
+++ b/contracts/periphery/erc7786/IERC7786.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.8.20;
+
+/**
+ * @title IERC7786GatewaySource
+ * @notice Interface for ERC-7786 source gateways, contracts that offer a protocol
+ * to send a message to a recipient on another chain.
+ * See https://eips.ethereum.org/EIPS/eip-7786
+ */
+interface IERC7786GatewaySource {
+    /**
+     * @notice Signals that a would-be sender has requested a message to be sent
+     * @param sendId Unique identifier to track the lifecycle of the message in the
+     * source gateway. May be zero if the gateway does not generate one.
+     * @param sender Binary Interoperable Address (ERC-7930) of the sender
+     * @param recipient Binary Interoperable Address (ERC-7930) of the recipient
+     * @param payload Message payload
+     * @param value Native token value sent with the message
+     * @param attributes List of attributes, each element is the concatenation of a
+     * bytes4 key and the ABI-encoded value
+     */
+    event MessageSent(
+        bytes32 indexed sendId,
+        bytes sender,
+        bytes recipient,
+        bytes payload,
+        uint256 value,
+        bytes[] attributes
+    );
+
+    /**
+     * @dev An unsupported attribute was included in the attributes list
+     */
+    error UnsupportedAttribute(bytes4 selector);
+
+    /**
+     * @notice Returns whether an attribute (identified by its key) is supported by the gateway
+     * @param selector The 4-byte attribute key
+     */
+    function supportsAttribute(bytes4 selector) external view returns (bool);
+
+    /**
+     * @notice Initiates the sending of a message
+     * @param recipient Binary Interoperable Address (ERC-7930) of the recipient
+     * @param payload Message payload
+     * @param attributes List of attributes, each element is the concatenation of a
+     * bytes4 key and the ABI-encoded value
+     * @return sendId Unique non-zero send identifier, or zero
+     */
+    function sendMessage(
+        bytes calldata recipient,
+        bytes calldata payload,
+        bytes[] calldata attributes
+    ) external payable returns (bytes32 sendId);
+}
+
+/**
+ * @title IERC7786Recipient
+ * @notice Interface that must be implemented by contracts receiving
+ * cross-chain messages through an ERC-7786 destination gateway.
+ * See https://eips.ethereum.org/EIPS/eip-7786
+ */
+interface IERC7786Recipient {
+    /**
+     * @notice Delivery of a message sent from another chain
+     * @dev The recipient must validate that the caller of this function is a known gateway
+     * @param receiveId Unique identifier (for the calling gateway) of the message being relayed
+     * @param sender Binary Interoperable Address (ERC-7930) of the sender
+     * @param payload Message payload
+     * @return Must return IERC7786Recipient.receiveMessage.selector (0x2432ef26)
+     */
+    function receiveMessage(
+        bytes32 receiveId,
+        bytes calldata sender,
+        bytes calldata payload
+    ) external payable returns (bytes4);
+}

--- a/contracts/periphery/erc7786/InteroperableAddress.sol
+++ b/contracts/periphery/erc7786/InteroperableAddress.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+pragma solidity ^0.8.20;
+
+/**
+ * @title InteroperableAddress
+ * @notice Minimal library to format and parse ERC-7930 v1 Interoperable Addresses
+ * for the eip155 (EVM) namespace.
+ * See https://eips.ethereum.org/EIPS/eip-7930
+ *
+ * Binary format (version 1):
+ * | Version (2B) | ChainType (2B) | ChainReferenceLength (1B) | ChainReference | AddressLength (1B) | Address |
+ *
+ * For the eip155 namespace (ChainType 0x0000), the chain reference is the chain id
+ * encoded as a minimal-length big-endian unsigned integer, and the address is the
+ * 20-byte EVM address.
+ */
+library InteroperableAddress {
+    /// @dev ERC-7930 version 1
+    bytes2 internal constant VERSION_V1 = 0x0001;
+
+    /// @dev CAIP-350 eip155 (EVM) namespace
+    bytes2 internal constant CHAIN_TYPE_EIP155 = 0x0000;
+
+    /**
+     * @dev The provided bytes are not a canonical ERC-7930 v1 eip155 interoperable address
+     */
+    error InvalidEvmV1InteroperableAddress();
+
+    /**
+     * @notice Formats a chainId + EVM address pair as an ERC-7930 v1 eip155 interoperable address
+     * @param chainId EIP-155 chain id
+     * @param addr EVM address
+     */
+    function formatEvmV1(
+        uint256 chainId,
+        address addr
+    ) internal pure returns (bytes memory) {
+        bytes memory chainReference = _toMinimalBigEndian(chainId);
+        return
+            abi.encodePacked(
+                VERSION_V1,
+                CHAIN_TYPE_EIP155,
+                uint8(chainReference.length),
+                chainReference,
+                uint8(20),
+                addr
+            );
+    }
+
+    /**
+     * @notice Parses an ERC-7930 v1 eip155 interoperable address into a chainId + EVM address pair
+     * @dev Reverts if the input is not canonical: version must be 1, chain type must be
+     * eip155, the chain reference must be a minimal-length big-endian integer (no leading
+     * zeros, max 32 bytes) and the address must be exactly 20 bytes. A zero-length chain
+     * reference is rejected since messages need an explicit destination chain.
+     * @param interoperableAddress The ERC-7930 encoded address
+     * @return chainId EIP-155 chain id
+     * @return addr EVM address
+     */
+    function parseEvmV1(
+        bytes memory interoperableAddress
+    ) internal pure returns (uint256 chainId, address addr) {
+        // Minimum length: 2 (version) + 2 (chain type) + 1 (chain ref length)
+        // + 1 (chain ref, at least 1 byte) + 1 (address length) + 20 (address)
+        if (interoperableAddress.length < 27) {
+            revert InvalidEvmV1InteroperableAddress();
+        }
+
+        if (
+            bytes2(_readBytes32(interoperableAddress, 0)) != VERSION_V1 ||
+            bytes2(_readBytes32(interoperableAddress, 2)) != CHAIN_TYPE_EIP155
+        ) {
+            revert InvalidEvmV1InteroperableAddress();
+        }
+
+        uint256 chainReferenceLength = uint8(interoperableAddress[4]);
+        if (chainReferenceLength == 0 || chainReferenceLength > 32) {
+            revert InvalidEvmV1InteroperableAddress();
+        }
+
+        // Enforce canonical (minimal-length big-endian) chain reference encoding
+        if (chainReferenceLength > 1 && interoperableAddress[5] == 0) {
+            revert InvalidEvmV1InteroperableAddress();
+        }
+
+        // Check exact total length and a 20-byte address field
+        if (
+            interoperableAddress.length != 26 + chainReferenceLength ||
+            uint8(interoperableAddress[5 + chainReferenceLength]) != 20
+        ) {
+            revert InvalidEvmV1InteroperableAddress();
+        }
+
+        chainId =
+            uint256(_readBytes32(interoperableAddress, 5)) >>
+            (8 * (32 - chainReferenceLength));
+
+        addr = address(
+            bytes20(
+                _readBytes32(interoperableAddress, 6 + chainReferenceLength)
+            )
+        );
+    }
+
+    /**
+     * @dev Encodes an unsigned integer as a minimal-length big-endian byte array.
+     * Returns a single zero byte for value 0 (a chain reference is always present).
+     */
+    function _toMinimalBigEndian(
+        uint256 value
+    ) private pure returns (bytes memory) {
+        uint256 length = 1;
+        uint256 tmp = value;
+        while (tmp > 0xff) {
+            length++;
+            tmp >>= 8;
+        }
+        bytes memory result = new bytes(length);
+        for (uint256 i = length; i > 0; i--) {
+            result[i - 1] = bytes1(uint8(value));
+            value >>= 8;
+        }
+        return result;
+    }
+
+    /**
+     * @dev Reads 32 bytes from a bytes array starting at `offset` (data may be shorter,
+     * remaining bytes are dirty memory past the array and must be masked by the caller).
+     */
+    function _readBytes32(
+        bytes memory data,
+        uint256 offset
+    ) private pure returns (bytes32 result) {
+        /* solhint-disable no-inline-assembly */
+        assembly {
+            result := mload(add(add(data, 0x20), offset))
+        }
+        /* solhint-enable no-inline-assembly */
+    }
+}

--- a/test/contractsv2/erc-7786/ERC7786Gateway.test.ts
+++ b/test/contractsv2/erc-7786/ERC7786Gateway.test.ts
@@ -1,0 +1,620 @@
+import { expect } from 'chai';
+import { ethers, upgrades } from 'hardhat';
+import { MTBridge, mtBridgeUtils } from '@0xpolygonhermez/zkevm-commonjs';
+import {
+    AgglayerBridge,
+    AgglayerERC7786Gateway,
+    ERC7786RecipientMock,
+    PolygonZkEVMGlobalExitRoot,
+} from '../../../typechain-types';
+
+const MerkleTreeBridge = MTBridge;
+const { verifyMerkleProof, getLeafValue } = mtBridgeUtils;
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const _GLOBAL_INDEX_MAINNET_FLAG = 2n ** 64n;
+
+function computeGlobalIndex(indexLocal: any, indexRollup: any, isMainnet: boolean) {
+    if (isMainnet === true) {
+        return BigInt(indexLocal) + _GLOBAL_INDEX_MAINNET_FLAG;
+    }
+    return BigInt(indexLocal) + BigInt(indexRollup) * 2n ** 32n;
+}
+
+/**
+ * Encodes an ERC-7930 v1 eip155 interoperable address
+ */
+function encodeInteroperableAddress(chainId: bigint, address: string): string {
+    let chainIdHex = chainId.toString(16);
+    if (chainIdHex.length % 2 === 1) {
+        chainIdHex = `0${chainIdHex}`;
+    }
+    const chainReferenceLength = chainIdHex.length / 2;
+    return ethers.concat([
+        '0x0001', // version
+        '0x0000', // chain type (eip155)
+        ethers.toBeHex(chainReferenceLength, 1),
+        `0x${chainIdHex}`,
+        '0x14', // address length (20)
+        address,
+    ]);
+}
+
+const FORCE_UPDATE_GER_SELECTOR = ethers.id('forceUpdateGlobalExitRoot(bool)').slice(0, 10);
+
+/**
+ * Encodes the forceUpdateGlobalExitRoot(bool) ERC-7786 attribute
+ */
+function encodeForceUpdateGERAttribute(value: boolean): string {
+    return ethers.concat([FORCE_UPDATE_GER_SELECTOR, ethers.AbiCoder.defaultAbiCoder().encode(['bool'], [value])]);
+}
+
+describe('AgglayerERC7786Gateway', () => {
+    upgrades.silenceWarnings();
+
+    let bridgeContract: AgglayerBridge;
+    let globalExitRootContract: PolygonZkEVMGlobalExitRoot;
+    let gatewayContract: AgglayerERC7786Gateway;
+    let recipientContract: ERC7786RecipientMock;
+
+    let deployer: any;
+    let rollupManager: any;
+    let acc1: any;
+    let remoteGateway: any;
+
+    let localChainId: bigint;
+
+    const networkIDMainnet = 0;
+    const networkIDRollup = 1;
+    const remoteChainId = 1101n;
+
+    const LEAF_TYPE_MESSAGE = 1;
+
+    const payload = '0x123456789abcdef0';
+
+    beforeEach('Deploy contracts', async () => {
+        [deployer, rollupManager, acc1, remoteGateway] = await ethers.getSigners();
+
+        localChainId = (await ethers.provider.getNetwork()).chainId;
+
+        // deploy bridge
+        const bridgeFactory = await ethers.getContractFactory('AgglayerBridge');
+        bridgeContract = (await upgrades.deployProxy(bridgeFactory, [], {
+            initializer: false,
+            unsafeAllow: ['constructor', 'missing-initializer', 'missing-initializer-call'],
+        })) as unknown as AgglayerBridge;
+
+        // deploy global exit root manager
+        const globalExitRootFactory = await ethers.getContractFactory('PolygonZkEVMGlobalExitRoot');
+        globalExitRootContract = await globalExitRootFactory.deploy(rollupManager.address, bridgeContract.target);
+
+        await bridgeContract.initialize(
+            networkIDMainnet,
+            ethers.ZeroAddress, // zero for ether
+            ethers.ZeroAddress, // zero for ether
+            globalExitRootContract.target,
+            rollupManager.address,
+            '0x',
+        );
+
+        // deploy ERC-7786 gateway
+        const gatewayFactory = await ethers.getContractFactory('AgglayerERC7786Gateway');
+        gatewayContract = await gatewayFactory.deploy(bridgeContract.target, deployer.address);
+
+        // deploy ERC-7786 recipient mock
+        const recipientFactory = await ethers.getContractFactory('ERC7786RecipientMock');
+        recipientContract = await recipientFactory.deploy();
+    });
+
+    describe('constructor and owner configuration', () => {
+        it('should set the bridge, local network id and owner', async () => {
+            expect(await gatewayContract.bridge()).to.be.equal(bridgeContract.target);
+            expect(await gatewayContract.localNetworkID()).to.be.equal(networkIDMainnet);
+            expect(await gatewayContract.owner()).to.be.equal(deployer.address);
+            expect(await gatewayContract.nonce()).to.be.equal(0);
+        });
+
+        it('should register a remote network and expose the mappings', async () => {
+            await expect(gatewayContract.registerRemoteNetwork(remoteChainId, networkIDRollup, remoteGateway.address))
+                .to.emit(gatewayContract, 'RemoteNetworkRegistered')
+                .withArgs(remoteChainId, networkIDRollup, remoteGateway.address);
+
+            expect(await gatewayContract.chainIdToNetworkID(remoteChainId)).to.be.equal(networkIDRollup);
+            expect(await gatewayContract.networkIDToChainId(networkIDRollup)).to.be.equal(remoteChainId);
+            expect(await gatewayContract.remoteGateways(networkIDRollup)).to.be.equal(remoteGateway.address);
+        });
+
+        it('should revert registering chain id zero', async () => {
+            await expect(
+                gatewayContract.registerRemoteNetwork(0, networkIDRollup, remoteGateway.address),
+            ).to.be.revertedWithCustomError(gatewayContract, 'InvalidZeroValue');
+        });
+
+        it('should revert registering a zero remote gateway', async () => {
+            await expect(
+                gatewayContract.registerRemoteNetwork(remoteChainId, networkIDRollup, ethers.ZeroAddress),
+            ).to.be.revertedWithCustomError(gatewayContract, 'InvalidZeroValue');
+        });
+
+        it('should revert when a non-owner registers a remote network', async () => {
+            await expect(
+                gatewayContract
+                    .connect(acc1)
+                    .registerRemoteNetwork(remoteChainId, networkIDRollup, remoteGateway.address),
+            ).to.be.revertedWithCustomError(gatewayContract, 'OwnableUnauthorizedAccount');
+        });
+
+        it('should revert chainIdToNetworkID for an unregistered chain', async () => {
+            await expect(gatewayContract.chainIdToNetworkID(remoteChainId))
+                .to.be.revertedWithCustomError(gatewayContract, 'UnregisteredChain')
+                .withArgs(remoteChainId);
+        });
+    });
+
+    describe('supportsAttribute', () => {
+        it('should support forceUpdateGlobalExitRoot(bool) only', async () => {
+            expect(await gatewayContract.supportsAttribute(FORCE_UPDATE_GER_SELECTOR)).to.be.equal(true);
+            expect(await gatewayContract.FORCE_UPDATE_GLOBAL_EXIT_ROOT_ATTRIBUTE()).to.be.equal(
+                FORCE_UPDATE_GER_SELECTOR,
+            );
+            expect(await gatewayContract.supportsAttribute('0x12345678')).to.be.equal(false);
+        });
+    });
+
+    describe('sendMessage', () => {
+        beforeEach('Register remote network', async () => {
+            await gatewayContract.registerRemoteNetwork(remoteChainId, networkIDRollup, remoteGateway.address);
+        });
+
+        it('should send a message through the bridge and emit MessageSent', async () => {
+            const recipient = encodeInteroperableAddress(remoteChainId, acc1.address);
+
+            const expectedSendId = ethers.keccak256(
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    ['uint256', 'address', 'uint256'],
+                    [localChainId, gatewayContract.target, 0],
+                ),
+            );
+            const expectedMetadata = ethers.AbiCoder.defaultAbiCoder().encode(
+                ['bytes32', 'address', 'address', 'bytes'],
+                [expectedSendId, deployer.address, acc1.address, payload],
+            );
+            const expectedSender = encodeInteroperableAddress(localChainId, deployer.address);
+
+            const depositCount = await bridgeContract.depositCount();
+
+            await expect(gatewayContract.sendMessage(recipient, payload, []))
+                .to.emit(gatewayContract, 'MessageSent')
+                .withArgs(expectedSendId, expectedSender, recipient, payload, 0, [])
+                .to.emit(bridgeContract, 'BridgeEvent')
+                .withArgs(
+                    LEAF_TYPE_MESSAGE,
+                    networkIDMainnet,
+                    gatewayContract.target,
+                    networkIDRollup,
+                    remoteGateway.address,
+                    0,
+                    expectedMetadata,
+                    depositCount,
+                );
+
+            expect(await gatewayContract.nonce()).to.be.equal(1);
+        });
+
+        it('should generate unique send ids on consecutive messages', async () => {
+            const recipient = encodeInteroperableAddress(remoteChainId, acc1.address);
+
+            const sendId0 = await gatewayContract.sendMessage.staticCall(recipient, payload, []);
+            await gatewayContract.sendMessage(recipient, payload, []);
+            const sendId1 = await gatewayContract.sendMessage.staticCall(recipient, payload, []);
+
+            expect(sendId0).to.not.be.equal(sendId1);
+            expect(sendId0).to.not.be.equal(ethers.ZeroHash);
+        });
+
+        it('should forward native value through the bridge', async () => {
+            const recipient = encodeInteroperableAddress(remoteChainId, acc1.address);
+            const amount = ethers.parseEther('1');
+
+            await expect(gatewayContract.sendMessage(recipient, payload, [], { value: amount })).to.emit(
+                gatewayContract,
+                'MessageSent',
+            );
+
+            // Value is escrowed in the bridge, not in the gateway
+            expect(await ethers.provider.getBalance(bridgeContract.target)).to.be.equal(amount);
+            expect(await ethers.provider.getBalance(gatewayContract.target)).to.be.equal(0);
+        });
+
+        it('should handle the forceUpdateGlobalExitRoot attribute', async () => {
+            const recipient = encodeInteroperableAddress(remoteChainId, acc1.address);
+
+            // forceUpdateGlobalExitRoot = false does not update the mainnet exit root
+            await gatewayContract.sendMessage(recipient, payload, [encodeForceUpdateGERAttribute(false)]);
+            expect(await globalExitRootContract.lastMainnetExitRoot()).to.be.equal(ethers.ZeroHash);
+
+            // forceUpdateGlobalExitRoot = true updates the mainnet exit root
+            await gatewayContract.sendMessage(recipient, payload, [encodeForceUpdateGERAttribute(true)]);
+            expect(await globalExitRootContract.lastMainnetExitRoot()).to.not.be.equal(ethers.ZeroHash);
+        });
+
+        it('should revert on unsupported attributes', async () => {
+            const recipient = encodeInteroperableAddress(remoteChainId, acc1.address);
+
+            // Unknown selector
+            const unknownAttribute = ethers.concat([
+                '0x12345678',
+                ethers.AbiCoder.defaultAbiCoder().encode(['bool'], [true]),
+            ]);
+            await expect(gatewayContract.sendMessage(recipient, payload, [unknownAttribute]))
+                .to.be.revertedWithCustomError(gatewayContract, 'UnsupportedAttribute')
+                .withArgs('0x12345678');
+
+            // Known selector but invalid length
+            await expect(
+                gatewayContract.sendMessage(recipient, payload, [FORCE_UPDATE_GER_SELECTOR]),
+            ).to.be.revertedWithCustomError(gatewayContract, 'UnsupportedAttribute');
+
+            // Attribute shorter than 4 bytes
+            await expect(gatewayContract.sendMessage(recipient, payload, ['0x12'])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'UnsupportedAttribute',
+            );
+        });
+
+        it('should revert on unregistered destination chain', async () => {
+            const unregisteredChainId = 424242n;
+            const recipient = encodeInteroperableAddress(unregisteredChainId, acc1.address);
+
+            await expect(gatewayContract.sendMessage(recipient, payload, []))
+                .to.be.revertedWithCustomError(gatewayContract, 'UnregisteredChain')
+                .withArgs(unregisteredChainId);
+        });
+
+        it('should revert on malformed ERC-7930 recipients', async () => {
+            const validRecipient = encodeInteroperableAddress(remoteChainId, acc1.address);
+
+            // Too short
+            await expect(gatewayContract.sendMessage('0x0001', payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+
+            // Wrong version (0x0002)
+            const wrongVersion = ethers.concat(['0x0002', ethers.dataSlice(validRecipient, 2)]);
+            await expect(gatewayContract.sendMessage(wrongVersion, payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+
+            // Wrong chain type (0x0002 = solana)
+            const wrongChainType = ethers.concat(['0x0001', '0x0002', ethers.dataSlice(validRecipient, 4)]);
+            await expect(gatewayContract.sendMessage(wrongChainType, payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+
+            // Non-minimal chain reference encoding (leading zero byte)
+            const nonMinimal = ethers.concat([
+                '0x0001',
+                '0x0000',
+                '0x03',
+                '0x00044d', // 1101 encoded with a leading zero
+                '0x14',
+                acc1.address,
+            ]);
+            await expect(gatewayContract.sendMessage(nonMinimal, payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+
+            // Chain reference longer than 32 bytes
+            const chainRefTooLong = ethers.concat([
+                '0x0001',
+                '0x0000',
+                '0x21',
+                `0x01${'00'.repeat(32)}`,
+                '0x14',
+                acc1.address,
+            ]);
+            await expect(gatewayContract.sendMessage(chainRefTooLong, payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+
+            // Wrong address length (19 bytes)
+            const wrongAddressLength = ethers.concat([
+                '0x0001',
+                '0x0000',
+                '0x02',
+                '0x044d',
+                '0x13',
+                ethers.dataSlice(acc1.address, 0, 19),
+            ]);
+            await expect(gatewayContract.sendMessage(wrongAddressLength, payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+
+            // Trailing bytes after the address
+            const trailingBytes = ethers.concat([validRecipient, '0xff']);
+            await expect(gatewayContract.sendMessage(trailingBytes, payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+
+            // Chain identifier only (zero-length address is not a valid recipient)
+            const chainIdentifier = ethers.concat(['0x0001', '0x0000', '0x02', '0x044d', '0x00']);
+            await expect(gatewayContract.sendMessage(chainIdentifier, payload, [])).to.be.revertedWithCustomError(
+                gatewayContract,
+                'InvalidEvmV1InteroperableAddress',
+            );
+        });
+
+        it('should revert when destination is the local network', async () => {
+            // Register the local chain id pointing to the local network id
+            await gatewayContract.registerRemoteNetwork(localChainId, networkIDMainnet, remoteGateway.address);
+            const recipient = encodeInteroperableAddress(localChainId, acc1.address);
+
+            await expect(gatewayContract.sendMessage(recipient, payload, [])).to.be.revertedWithCustomError(
+                bridgeContract,
+                'DestinationNetworkInvalid',
+            );
+        });
+    });
+
+    describe('onMessageReceived', () => {
+        const sendId = ethers.keccak256(ethers.toUtf8Bytes('test-send-id'));
+        let remoteSender: string;
+        let metadata: string;
+
+        beforeEach('Register origin network', async () => {
+            await gatewayContract.registerRemoteNetwork(remoteChainId, networkIDRollup, remoteGateway.address);
+
+            remoteSender = acc1.address;
+            metadata = ethers.AbiCoder.defaultAbiCoder().encode(
+                ['bytes32', 'address', 'address', 'bytes'],
+                [sendId, remoteSender, recipientContract.target, payload],
+            );
+        });
+
+        it('should revert when not called by the bridge', async () => {
+            await expect(
+                gatewayContract.onMessageReceived(remoteGateway.address, networkIDRollup, metadata),
+            ).to.be.revertedWithCustomError(gatewayContract, 'OnlyBridge');
+        });
+
+        describe('called by the bridge (impersonated)', () => {
+            let bridgeSigner: any;
+
+            beforeEach('Impersonate bridge', async () => {
+                await ethers.provider.send('hardhat_impersonateAccount', [bridgeContract.target]);
+                bridgeSigner = await ethers.getSigner(bridgeContract.target as string);
+                await ethers.provider.send('hardhat_setBalance', [
+                    bridgeContract.target,
+                    ethers.toBeHex(ethers.parseEther('100')),
+                ]);
+            });
+
+            afterEach('Stop impersonating bridge', async () => {
+                await ethers.provider.send('hardhat_stopImpersonatingAccount', [bridgeContract.target]);
+            });
+
+            it('should deliver the message to the recipient', async () => {
+                const amount = ethers.parseEther('2');
+                await gatewayContract
+                    .connect(bridgeSigner)
+                    .onMessageReceived(remoteGateway.address, networkIDRollup, metadata, { value: amount });
+
+                expect(await recipientContract.lastReceiveId()).to.be.equal(sendId);
+                expect(await recipientContract.lastSender()).to.be.equal(
+                    encodeInteroperableAddress(remoteChainId, remoteSender),
+                );
+                expect(await recipientContract.lastPayload()).to.be.equal(payload);
+                expect(await recipientContract.lastValue()).to.be.equal(amount);
+                expect(await recipientContract.lastCaller()).to.be.equal(gatewayContract.target);
+                expect(await recipientContract.receivedCount()).to.be.equal(1);
+                expect(await ethers.provider.getBalance(recipientContract.target)).to.be.equal(amount);
+            });
+
+            it('should revert on untrusted origin gateway', async () => {
+                await expect(
+                    gatewayContract.connect(bridgeSigner).onMessageReceived(acc1.address, networkIDRollup, metadata),
+                )
+                    .to.be.revertedWithCustomError(gatewayContract, 'UntrustedOriginGateway')
+                    .withArgs(networkIDRollup, acc1.address);
+
+                // Zero origin address on a network without registered gateway
+                const networkIDRollup2 = 2;
+                await expect(
+                    gatewayContract
+                        .connect(bridgeSigner)
+                        .onMessageReceived(ethers.ZeroAddress, networkIDRollup2, metadata),
+                )
+                    .to.be.revertedWithCustomError(gatewayContract, 'UntrustedOriginGateway')
+                    .withArgs(networkIDRollup2, ethers.ZeroAddress);
+            });
+
+            it('should revert when the recipient returns an invalid selector', async () => {
+                await recipientContract.setReturnInvalidSelector(true);
+
+                await expect(
+                    gatewayContract
+                        .connect(bridgeSigner)
+                        .onMessageReceived(remoteGateway.address, networkIDRollup, metadata),
+                ).to.be.revertedWithCustomError(gatewayContract, 'InvalidRecipientReturnValue');
+            });
+
+            it('should revert when the recipient is not a contract', async () => {
+                const badMetadata = ethers.AbiCoder.defaultAbiCoder().encode(
+                    ['bytes32', 'address', 'address', 'bytes'],
+                    [sendId, remoteSender, acc1.address, payload],
+                );
+
+                await expect(
+                    gatewayContract
+                        .connect(bridgeSigner)
+                        .onMessageReceived(remoteGateway.address, networkIDRollup, badMetadata),
+                ).to.be.reverted;
+            });
+        });
+    });
+
+    describe('end-to-end claim through the bridge', () => {
+        beforeEach('Register origin network', async () => {
+            await gatewayContract.registerRemoteNetwork(remoteChainId, networkIDRollup, remoteGateway.address);
+        });
+
+        it('should claim a bridged message and deliver it to the ERC-7786 recipient', async () => {
+            const originNetwork = networkIDRollup;
+            const amount = ethers.parseEther('3');
+            const destinationNetwork = networkIDMainnet;
+            const remoteSender = acc1.address;
+
+            const sendId = ethers.keccak256(
+                ethers.AbiCoder.defaultAbiCoder().encode(
+                    ['uint256', 'address', 'uint256'],
+                    [remoteChainId, remoteGateway.address, 0],
+                ),
+            );
+            const metadata = ethers.AbiCoder.defaultAbiCoder().encode(
+                ['bytes32', 'address', 'address', 'bytes'],
+                [sendId, remoteSender, recipientContract.target, payload],
+            );
+            const metadataHash = ethers.solidityPackedKeccak256(['bytes'], [metadata]);
+
+            // Compute the rollup local exit tree with the message leaf targeting the gateway
+            const height = 32;
+            const merkleTreeLocal = new MerkleTreeBridge(height);
+            const leafValue = getLeafValue(
+                LEAF_TYPE_MESSAGE,
+                originNetwork,
+                remoteGateway.address, // originAddress: counterpart gateway called bridgeMessage
+                destinationNetwork,
+                gatewayContract.target, // destinationAddress: this gateway
+                amount,
+                metadataHash,
+            );
+            merkleTreeLocal.add(leafValue);
+            const rootLocalRollup = merkleTreeLocal.getRoot();
+
+            // Rollup exit tree containing the rollup local root
+            const merkleTreeRollup = new MerkleTreeBridge(height);
+            merkleTreeRollup.add(rootLocalRollup);
+            const rollupRoot = merkleTreeRollup.getRoot();
+
+            // Add the rollup exit root to the global exit root manager
+            const mainnetExitRoot = await globalExitRootContract.lastMainnetExitRoot();
+            await expect(globalExitRootContract.connect(rollupManager).updateExitRoot(rollupRoot))
+                .to.emit(globalExitRootContract, 'UpdateGlobalExitRoot')
+                .withArgs(mainnetExitRoot, rollupRoot);
+            const rollupExitRootSC = await globalExitRootContract.lastRollupExitRoot();
+            expect(rollupExitRootSC).to.be.equal(rollupRoot);
+
+            const index = 0;
+            const proofLocal = merkleTreeLocal.getProofTreeByIndex(index);
+            const proofRollup = merkleTreeRollup.getProofTreeByIndex(index);
+            const globalIndex = computeGlobalIndex(index, index, false);
+            expect(verifyMerkleProof(leafValue, proofLocal, index, rootLocalRollup)).to.be.equal(true);
+
+            // Fund the bridge with ether so the claim can forward the amount
+            await bridgeContract.bridgeAsset(
+                networkIDRollup,
+                deployer.address,
+                amount,
+                ethers.ZeroAddress,
+                true,
+                '0x',
+                { value: amount },
+            );
+
+            // Claim the message: bridge -> gateway.onMessageReceived -> recipient.receiveMessage
+            await expect(
+                bridgeContract.claimMessage(
+                    proofLocal,
+                    proofRollup,
+                    globalIndex,
+                    mainnetExitRoot,
+                    rollupExitRootSC,
+                    originNetwork,
+                    remoteGateway.address,
+                    destinationNetwork,
+                    gatewayContract.target,
+                    amount,
+                    metadata,
+                ),
+            )
+                .to.emit(bridgeContract, 'ClaimEvent')
+                .withArgs(globalIndex, originNetwork, remoteGateway.address, gatewayContract.target, amount);
+
+            // The recipient received the message and the ether
+            expect(await recipientContract.lastReceiveId()).to.be.equal(sendId);
+            expect(await recipientContract.lastSender()).to.be.equal(
+                encodeInteroperableAddress(remoteChainId, remoteSender),
+            );
+            expect(await recipientContract.lastPayload()).to.be.equal(payload);
+            expect(await recipientContract.lastValue()).to.be.equal(amount);
+            expect(await recipientContract.lastCaller()).to.be.equal(gatewayContract.target);
+            expect(await ethers.provider.getBalance(recipientContract.target)).to.be.equal(amount);
+            expect(await ethers.provider.getBalance(gatewayContract.target)).to.be.equal(0);
+        });
+
+        it('should fail the claim when the origin gateway is untrusted', async () => {
+            const originNetwork = networkIDRollup;
+            const amount = 0n;
+            const destinationNetwork = networkIDMainnet;
+            const untrustedOrigin = acc1.address;
+
+            const sendId = ethers.ZeroHash;
+            const metadata = ethers.AbiCoder.defaultAbiCoder().encode(
+                ['bytes32', 'address', 'address', 'bytes'],
+                [sendId, acc1.address, recipientContract.target, payload],
+            );
+            const metadataHash = ethers.solidityPackedKeccak256(['bytes'], [metadata]);
+
+            const height = 32;
+            const merkleTreeLocal = new MerkleTreeBridge(height);
+            const leafValue = getLeafValue(
+                LEAF_TYPE_MESSAGE,
+                originNetwork,
+                untrustedOrigin, // originAddress is NOT the registered counterpart gateway
+                destinationNetwork,
+                gatewayContract.target,
+                amount,
+                metadataHash,
+            );
+            merkleTreeLocal.add(leafValue);
+            const rootLocalRollup = merkleTreeLocal.getRoot();
+
+            const merkleTreeRollup = new MerkleTreeBridge(height);
+            merkleTreeRollup.add(rootLocalRollup);
+            const rollupRoot = merkleTreeRollup.getRoot();
+
+            const mainnetExitRoot = await globalExitRootContract.lastMainnetExitRoot();
+            await globalExitRootContract.connect(rollupManager).updateExitRoot(rollupRoot);
+            const rollupExitRootSC = await globalExitRootContract.lastRollupExitRoot();
+
+            const index = 0;
+            const proofLocal = merkleTreeLocal.getProofTreeByIndex(index);
+            const proofRollup = merkleTreeRollup.getProofTreeByIndex(index);
+            const globalIndex = computeGlobalIndex(index, index, false);
+
+            // The gateway rejects the message, so the whole claim reverts
+            await expect(
+                bridgeContract.claimMessage(
+                    proofLocal,
+                    proofRollup,
+                    globalIndex,
+                    mainnetExitRoot,
+                    rollupExitRootSC,
+                    originNetwork,
+                    untrustedOrigin,
+                    destinationNetwork,
+                    gatewayContract.target,
+                    amount,
+                    metadata,
+                ),
+            ).to.be.revertedWithCustomError(bridgeContract, 'MessageFailed');
+        });
+    });
+});

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -24,6 +24,7 @@ Tools will be documented as they are used. If you use a tool, update this file w
 | `deployPolygonDataCommittee/` | Deploy data committee for validium |
 | `deploySovereignTest/` | Deploy sovereign chain for testing |
 | `deployAggOracleCommittee/` | Deploy oracle committee |
+| `erc7786/` | Deploy AgglayerERC7786Gateway (ERC-7786 adapter for the bridge) on L1 and/or L2, with optional remote network registration |
 | `checkRollupVersions/` | Check rollup version info |
 | `getRollupData/` | Get rollup data from contracts |
 | `getBridgeEvents/` | Get bridge events |

--- a/tools/erc7786/README.md
+++ b/tools/erc7786/README.md
@@ -1,0 +1,69 @@
+# Deploy ERC-7786 Gateway (AgglayerERC7786Gateway)
+
+Script to deploy `AgglayerERC7786Gateway.sol`, the [ERC-7786](https://eips.ethereum.org/EIPS/eip-7786) gateway adapter on top of the AgglayerBridge message-passing layer.
+
+## L1 vs L2
+
+The **same contract** is deployed on every network that wants to exchange ERC-7786 messages: L1 (Ethereum) and each L2/aggchain. There is no code difference between the L1 and L2 deployments, only the configuration differs:
+
+- **Constructor**: the address of the AgglayerBridge deployed on that network (the gateway reads its local Agglayer `networkID` from the bridge) and the owner.
+- **Post-deployment registration**: on each network, the owner must register every remote network it wants to talk to via `registerRemoteNetwork(chainId, networkID, gateway)`, where `gateway` is the counterpart `AgglayerERC7786Gateway` deployed on that remote network.
+
+For example, to connect L1 (networkID 0) with an L2 (networkID 1, chainId 1101):
+
+1. Deploy the gateway on L1 (pointing to the L1 bridge).
+2. Deploy the gateway on the L2 (pointing to the L2 bridge).
+3. On the L1 gateway, register the L2: `registerRemoteNetwork(1101, 1, <L2 gateway address>)`.
+4. On the L2 gateway, register L1: `registerRemoteNetwork(1, 0, <L1 gateway address>)`.
+
+Since the counterpart gateway address must be known to register it, either deploy on both networks first and then register (the script supports leaving `remoteNetworks` empty and registering later), or use deterministic deployment addresses.
+
+## Setup
+
+- Config file `deploy_erc7786_gateway.json`:
+  - `bridgeAddress`: AgglayerBridge address on the network being deployed to (mandatory)
+  - `owner`: gateway owner, allowed to register remote networks. If empty, defaults to the deployer
+  - `remoteNetworks`: optional array of remote networks to register right after deployment (only executed if the deployer is the owner). Each entry:
+    - `chainId`: EIP-155 chain id of the remote network
+    - `networkID`: Agglayer network id of the remote network
+    - `gateway`: counterpart `AgglayerERC7786Gateway` address on that network
+  - `deployerPvtKey`: private key deployer
+    - First option will load `deployerPvtKey`. Otherwise, `process.env.MNEMONIC` will be loaded from the `.env` file
+  - `maxFeePerGas`: set custom gas
+  - `maxPriorityFeePerGas`: set custom gas
+  - `multiplierGas`: set custom gas
+- A network should be selected when running the script
+  - examples: `--network sepolia` (L1) or `--network polygonZKEVMTestnet` (L2)
+  - This uses variables set in `hardhat.config.ts`
+  - Which uses some environment variables that should be set in `.env`
+
+## Usage
+
+- Copy configuration file:
+```
+cp ./tools/erc7786/deploy_erc7786_gateway.json.example ./tools/erc7786/deploy_erc7786_gateway.json
+```
+
+- Set your parameters
+- Run tool (once per network, L1 and/or L2):
+```
+npx hardhat run ./tools/erc7786/deployErc7786Gateway.ts --network <network>
+```
+
+- Output: `deploy_erc7786_gateway_output.json`:
+```
+{
+ "deployer": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+ "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+ "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
+ "localNetworkID": "0",
+ "erc7786GatewayContract": "0x851356ae760d987E095750cCeb3bC6014560891C",
+ "registeredRemoteNetworks": [
+  {
+   "chainId": 1101,
+   "networkID": 1,
+   "gateway": "0xc5a5C42992dECbae36851359345FE25997F5C42d"
+  }
+ ]
+}
+```

--- a/tools/erc7786/deployErc7786Gateway.ts
+++ b/tools/erc7786/deployErc7786Gateway.ts
@@ -1,0 +1,133 @@
+/* eslint-disable no-await-in-loop, no-use-before-define, no-lonely-if */
+/* eslint-disable no-console, no-inner-declarations, no-undef, import/no-unresolved */
+import path = require('path');
+import fs = require('fs');
+
+import * as dotenv from 'dotenv';
+import { ethers } from 'hardhat';
+import deployParameters from './deploy_erc7786_gateway.json';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+const pathOutput = path.resolve(__dirname, './deploy_erc7786_gateway_output.json');
+
+async function main() {
+    // Check mandatory parameters
+    const mandatoryDeploymentParameters = ['bridgeAddress'];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const parameterName of mandatoryDeploymentParameters) {
+        if ((deployParameters as any)[parameterName] === undefined || (deployParameters as any)[parameterName] === '') {
+            throw new Error(`Missing parameter: ${parameterName}`);
+        }
+    }
+
+    // Load provider
+    let currentProvider = ethers.provider;
+    if (deployParameters.multiplierGas || deployParameters.maxFeePerGas) {
+        if (process.env.HARDHAT_NETWORK !== 'hardhat') {
+            currentProvider = ethers.getDefaultProvider(
+                `https://${process.env.HARDHAT_NETWORK}.infura.io/v3/${process.env.INFURA_PROJECT_ID}`,
+            ) as any;
+            if (deployParameters.maxPriorityFeePerGas && deployParameters.maxFeePerGas) {
+                console.log(
+                    `Hardcoded gas used: MaxPriority${deployParameters.maxPriorityFeePerGas} gwei, MaxFee${deployParameters.maxFeePerGas} gwei`,
+                );
+                const FEE_DATA = new ethers.FeeData(
+                    null,
+                    ethers.parseUnits(deployParameters.maxFeePerGas, 'gwei'),
+                    ethers.parseUnits(deployParameters.maxPriorityFeePerGas, 'gwei'),
+                );
+
+                currentProvider.getFeeData = async () => FEE_DATA;
+            } else {
+                console.log('Multiplier gas used: ', deployParameters.multiplierGas);
+                async function overrideFeeData() {
+                    const feedata = await ethers.provider.getFeeData();
+                    return new ethers.FeeData(
+                        null,
+                        ((feedata.maxFeePerGas as bigint) * BigInt(deployParameters.multiplierGas)) / 1000n,
+                        ((feedata.maxPriorityFeePerGas as bigint) * BigInt(deployParameters.multiplierGas)) / 1000n,
+                    );
+                }
+                currentProvider.getFeeData = overrideFeeData;
+            }
+        }
+    }
+
+    // Load deployer
+    let deployer;
+    if (deployParameters.deployerPvtKey) {
+        deployer = new ethers.Wallet(deployParameters.deployerPvtKey, currentProvider);
+    } else if (process.env.MNEMONIC) {
+        deployer = ethers.HDNodeWallet.fromMnemonic(
+            ethers.Mnemonic.fromPhrase(process.env.MNEMONIC),
+            "m/44'/60'/0'/0/0",
+        ).connect(currentProvider);
+    } else {
+        [deployer] = await ethers.getSigners();
+    }
+
+    console.log('deploying with: ', deployer.address);
+
+    const { bridgeAddress } = deployParameters;
+    // Owner of the gateway (can register remote networks). Defaults to the deployer
+    const owner = deployParameters.owner || deployer.address;
+
+    // Sanity check: the bridge must expose networkID() on this network
+    const bridgeContract = await ethers.getContractAt('AgglayerBridge', bridgeAddress, deployer);
+    const localNetworkID = await bridgeContract.networkID();
+    console.log(`bridge ${bridgeAddress} has networkID: ${localNetworkID}`);
+
+    // Deploy the gateway (same contract on L1 and L2, only the bridge/owner differ)
+    const gatewayFactory = await ethers.getContractFactory('AgglayerERC7786Gateway', deployer);
+    const gatewayContract = await gatewayFactory.deploy(bridgeAddress, owner);
+    await gatewayContract.waitForDeployment();
+
+    console.log('#######################\n');
+    console.log('AgglayerERC7786Gateway deployed to:', gatewayContract.target);
+    console.log('local networkID:', localNetworkID.toString());
+    console.log('owner:', owner);
+    console.log('#######################\n');
+
+    // Register remote networks (only possible if the deployer is the owner)
+    const remoteNetworks = deployParameters.remoteNetworks || [];
+    const registeredNetworks = [];
+    if (remoteNetworks.length > 0) {
+        if (owner.toLowerCase() !== deployer.address.toLowerCase()) {
+            console.log('Skipping remote network registration: deployer is not the owner');
+        } else {
+            // eslint-disable-next-line no-restricted-syntax
+            for (const remoteNetwork of remoteNetworks) {
+                const { chainId, networkID, gateway } = remoteNetwork;
+                const tx = await gatewayContract.registerRemoteNetwork(chainId, networkID, gateway);
+                await tx.wait();
+                console.log(
+                    `registered remote network: chainId ${chainId}, networkID ${networkID}, gateway ${gateway}`,
+                );
+                registeredNetworks.push({ chainId, networkID, gateway });
+            }
+        }
+    }
+
+    const outputJson = {
+        deployer: deployer.address,
+        owner,
+        bridgeAddress,
+        localNetworkID: localNetworkID.toString(),
+        erc7786GatewayContract: gatewayContract.target,
+        registeredRemoteNetworks: registeredNetworks,
+    };
+
+    console.log('you can verify the contract address with:');
+    console.log(
+        `npx hardhat verify --constructor-args upgrade/arguments.js ${gatewayContract.target} --network ${process.env.HARDHAT_NETWORK}\n`,
+    );
+    console.log('Copy the following constructor arguments on: upgrade/arguments.js \n', [bridgeAddress, owner]);
+
+    fs.writeFileSync(pathOutput, JSON.stringify(outputJson, null, 1));
+}
+
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/tools/erc7786/deploy_erc7786_gateway.json.example
+++ b/tools/erc7786/deploy_erc7786_gateway.json.example
@@ -1,0 +1,15 @@
+{
+    "bridgeAddress": "0xaddress",
+    "owner": "",
+    "remoteNetworks": [
+        {
+            "chainId": 1101,
+            "networkID": 1,
+            "gateway": "0xaddress"
+        }
+    ],
+    "deployerPvtKey": "",
+    "maxFeePerGas": "",
+    "maxPriorityFeePerGas": "",
+    "multiplierGas": ""
+}


### PR DESCRIPTION
Add a standalone ERC-7786 gateway adapter that wraps the AgglayerBridge message-passing layer, with ERC-7930 interoperable address encoding, a deploy tool for L1/L2, and standalone tests.